### PR TITLE
Fix Get-AzureADAuditSignInLogs command

### DIFF
--- a/Scripts/Get-AzureLogs.ps1
+++ b/Scripts/Get-AzureLogs.ps1
@@ -53,7 +53,7 @@ function Get-ADSignInLogs {
 		write-logFile -Message "[INFO] Collecting the Azure Active Directory sign in logs"
 		$filePath = "Output\AzureAD\SignInLogs.json"
 
-		$signInLogs = Get-AzureADAuditSignInLogs
+		$signInLogs = Get-AzureADAuditSignInLogs -All $true
 		$signInLogs | ConvertTo-Json | Out-File -FilePath $filePath
 
 		write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"


### PR DESCRIPTION
Updated the command where no filter is specified to include all log results to match documentation. By default, the command would only return 1 day worth of signins. -All $true returns all signins (up to 30).