### PR TITLE
Update AzureActiveDirectorysign-inlogs.rst

### DIFF
--- a/docs/source/functionality/AzureActiveDirectorysign-inlogs.rst
+++ b/docs/source/functionality/AzureActiveDirectorysign-inlogs.rst
@@ -4,7 +4,7 @@ Use **Get-ADSignInLogs** to collect the contents of the Azure Active Directory s
 
 Usage
 """"""""""""""""""""""""""
-Running the script without any parameters will gather the Azure Active Directory sign-in log for the last 90 days:
+Running the script without any parameters will gather the Azure Active Directory sign-in log for the last 30 days:
 ::
 
    Get-ADSignInLogs


### PR DESCRIPTION
Adjusted sign in log documentation from 90 to 30 days. Azure AD sign-in logs are not retained for 90 days (this is likely from a reference to UAL retention).