### PR TITLE
Display timestamps in ISO8601 & fix StartDate and EndDate functions

### DIFF
--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -25,11 +25,8 @@ if (!(test-path $outputDir)) {
 Function StartDate
 {
 	if (($startDate -eq "") -Or ($null -eq $startDate)) {
-		$startDate = [datetime]::Now.ToUniversalTime().AddDays(-90)
-		$startDate = Get-Date $startDate -Format "yyyy-MM-dd HH:mm:ss"
-		write-LogFile -Message "[INFO] No start date provived by user setting the start date to: $startDate" -Color "Yellow"
-		
-		$script:StartDate = Get-Date $startDate -Format "yyyy-MM-dd HH:mm:ss"
+		$script:StartDate = [datetime]::Now.ToUniversalTime().AddDays(-90)
+		write-LogFile -Message "[INFO] No start date provived by user setting the start date to: $($script:StartDate.ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Yellow"
 	}
 	else
 	{
@@ -43,11 +40,8 @@ Function StartDate
 function EndDate
 {
 	if (($endDate -eq "") -Or ($null -eq $endDate)) {
-		$endDate = [datetime]::Now.ToUniversalTime()
-		$endDate = Get-Date $endDate -Format "yyyy-MM-dd HH:mm:ss"
-		write-LogFile -Message "[INFO] No end date provived by user setting the end date to: $endDate" -Color "Yellow"
-		
-		$script:endDate = Get-Date $endDate -Format "yyyy-MM-dd HH:mm:ss"
+		$script:EndDate = [datetime]::Now.ToUniversalTime()
+		write-LogFile -Message "[INFO] No end date provived by user setting the end date to: $($script:EndDate.ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Yellow"
 	}
 
 	else {

--- a/Scripts/Get-AdminAuditLog.ps1
+++ b/Scripts/Get-AdminAuditLog.ps1
@@ -52,7 +52,7 @@ function Get-AdminAuditLog {
 	StartDate
 	EndDate
 
-    Write-LogFile -Message "[INFO] Extracting all available Admin Audit Logs between $script:StartDate and $script:EndDate" -Color "Green"
+    Write-LogFile -Message "[INFO] Extracting all available Admin Audit Logs between $($script:StartDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($script:EndDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Green"
 
     $results = Search-AdminAuditLog -ResultSize 250000 -StartDate $script:startDate -EndDate $script:EndDate
     $results | epcsv $outputDirectory -NoTypeInformation -Append

--- a/Scripts/Get-MessageTraceLog.ps1
+++ b/Scripts/Get-MessageTraceLog.ps1
@@ -3,15 +3,12 @@ Function StartDateMTL
 {
 	if (($startDate -eq "") -Or ($null -eq $startDate))
 	{
-		$startDate = [datetime]::Now.ToUniversalTime().AddDays(-10)
-		$startDate = Get-Date $startDate -Format "yyyy-MM-dd HH:mm:ss"
-		write-LogFile -Message "[INFO] No start date provived by user setting the start date to: $startDate" -Color "Yellow"
-		
-		$script:startDate = Get-Date $startDate -Format "yyyy-MM-dd HH:mm:ss"
+		$script:StartDate = [datetime]::Now.ToUniversalTime().AddDays(-10)
+		write-LogFile -Message "[INFO] No start date provived by user setting the start date to: $($script:StartDate.ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Yellow"
 	}
 	else
 	{
-		$script:startDate = $startDate -as [datetime]
+		$script:StartDate = $startDate -as [datetime]
 		if (!$startDate) { write-LogFile -Message "[WARNING] Not A valid start date and time, make sure to use YYYY-MM-DD" -Color "Red"} 
 	}
 }
@@ -20,15 +17,12 @@ function EndDateMTL
 {
 	if (($endDate -eq "") -Or ($null -eq $endDate))
 	{
-		$endDate = [datetime]::Now.ToUniversalTime()
-		$endDate = Get-Date $endDate -Format "yyyy-MM-dd HH:mm:ss"
-		write-LogFile -Message "[INFO] No end date provived by user setting the end date to: $endDate" -Color "Yellow"
-		
-		$script:endDate = Get-Date $endDate -Format "yyyy-MM-dd HH:mm:ss"
+		$script:EndDate = [datetime]::Now.ToUniversalTime()
+		write-LogFile -Message "[INFO] No end date provived by user setting the end date to: $($script:EndDate.ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Yellow"
 	}
 	else
 	{
-		$script:endDate = $endDate -as [datetime]
+		$script:EndDate = $endDate -as [datetime]
 		if (!$endDate) {write-LogFile -Message "[WARNING] Not A valid end date and time, make sure to use YYYY-MM-DD" -Color "Red"} 
 	}
 }
@@ -102,7 +96,7 @@ function Get-MessageTraceLog
 	}
 	
 	if (($null -eq $UserIds) -Or ($UserIds -eq ""))  {
-		write-logFile -Message "[INFO] No users provided.. Getting the Message Trace Log for all users" -Color "Yellow"
+		write-logFile -Message "[INFO] No users provided. Getting the Message Trace Log for all users between $($script:StartDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($script:EndDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Yellow"
 		Get-mailbox -resultsize unlimited  |
 		ForEach-Object {
 			$outputFile = "Output\MessageTrace\"+$($_.PrimarySmtpAddress)+"-MTL.csv"
@@ -126,7 +120,7 @@ function Get-MessageTraceLog
 		$UserIds.Split(",") | foreach {
 			$user = $_
 			
-			write-logFile -Message "[INFO] Collecting the Message Trace Log for $user"
+			write-logFile -Message "[INFO] Collecting the Message Trace Log for $user between $($script:StartDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($script:EndDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))"
 			$outputFile = "Output\MessageTrace\"+$user+"-MTL.csv"
 
 			$ResultsRecipient = Get-MessageTrace -RecipientAddress $user -StartDate $script:startDate -EndDate $script:endDate -PageSize 5000

--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -106,7 +106,7 @@ function Get-UALAll
 	[DateTime]$currentStart = $script:StartDate
 	[DateTime]$currentEnd = $script:EndDate
 
-	Write-LogFile -Message "[INFO] Extracting all available audit logs between $currentStart and $currentEnd" -Color "Green"
+	Write-LogFile -Message "[INFO] Extracting all available audit logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Green"
 	
 	while ($currentStart -lt $script:EndDate) {	
 		$currentEnd = $currentStart.AddMinutes($Interval)
@@ -124,7 +124,7 @@ function Get-UALAll
 				else {
 					$interval = [math]::Round(($Interval/(($amountResults/5000)*1.25)),2)
 					$currentEnd = $currentStart.AddMinutes($Interval)
-					Write-LogFile -Message "[WARNING] $amountResults entries between $($currentStart) and $($currentEnd) exceeding the maximum of 5000 of entries" -Color "Red"
+					Write-LogFile -Message "[WARNING] $amountResults entries between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) exceeding the maximum of 5000 of entries" -Color "Red"
 					Write-LogFile -Message "[INFO] Temporary lowering time interval to $Interval minutes" -Color "Yellow"
 				}
 			}
@@ -152,14 +152,14 @@ function Get-UALAll
 				}
 				
 				else {
-					Write-LogFile -Message "No audit logs between $($currentStart) and $($currentEnd)"
+					Write-LogFile -Message "No audit logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))"
 					break
 				}
 			}
 				
 			$currentTotal = $results[0].ResultCount
 			$currentCount = $currentCount + $results.Count
-			Write-LogFile -Message "[INFO] Found $currentTotal audit logs between $($currentStart) and $($currentEnd)"
+			Write-LogFile -Message "[INFO] Found $currentTotal audit logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))"
 			
 			if ($currentTotal -eq $results[$results.Count - 1].ResultIndex) {
 				$message = "[INFO] Successfully retrieved $($currentCount) records out of total $($currentTotal) for the current time range. Moving on!"
@@ -309,7 +309,7 @@ function Get-UALGroup
 		New-Item -ItemType Directory -Force -Name $outputDir | Out-Null
 	}
 
-	write-logFile -Message "[INFO] Extracting all available audit logs between $script:StartDate and $script:EndDate"
+	write-logFile -Message "[INFO] Extracting all available audit logs between $($script:StartDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($script:EndDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))"
 	write-logFile -Message "[INFO] The following RecordType(s) are configured to be extracted:"
 	
 	foreach ($record in $recordTypes) {
@@ -343,7 +343,7 @@ function Get-UALGroup
 						else {
 							$Interval = [math]::Round(($Interval/(($amountResults/5000)*1.25)),2)
 							$currentEnd = $currentStart.AddMinutes($Interval)
-							Write-LogFile -Message "[WARNING] $amountResults entries between $($currentStart) and $($currentEnd) exceeding the maximum of 5000 of entries" -Color "Red"
+							Write-LogFile -Message "[WARNING] $amountResults entries between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) exceeding the maximum of 5000 of entries" -Color "Red"
 							Write-LogFile -Message "[INFO] Temporary lowering time interval to $Interval minutes" -Color "Yellow"
 						}
 					}
@@ -372,14 +372,14 @@ function Get-UALGroup
 							continue
 						}
 						else {
-							Write-LogFile -Message "No audit logs between $($currentStart) and $($currentEnd)"
+							Write-LogFile -Message "No audit logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))"
 							break
 						}
 					}
 							
 					$currentTotal = $results[0].ResultCount
 					$currentCount = $currentCount + $results.Count
-					Write-LogFile -Message "[INFO] Found $currentTotal audit logs between $($currentStart) and $($currentEnd)" -Color "Green"
+					Write-LogFile -Message "[INFO] Found $currentTotal audit logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Green"
 
 					if ($currentTotal -eq $results[$results.Count - 1].ResultIndex){
 						$message = "[INFO] Successfully retrieved $($currentCount) records out of total $($currentTotal) for the current time range. Moving on!"
@@ -508,7 +508,7 @@ function Get-UALSpecific
 		write-logFile -Message "[INFO] Output set to CSV"
 	}
 
-	write-logFile -Message "[INFO] Extracting all available audit logs between $script:StartDate and $script:EndDate"
+	write-logFile -Message "[INFO] Extracting all available audit logs between $($script:StartDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($script:EndDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))"
 	write-logFile -Message "[INFO] The following RecordType(s) are configured to be extracted:"
 
 	foreach ($record in $recordType) {
@@ -548,7 +548,7 @@ function Get-UALSpecific
 						else {
 							$interval = [math]::Round(($Interval/(($amountResults/5000)*1.25)),2)
 							$currentEnd = $currentStart.AddMinutes($Interval)
-							Write-LogFile -Message "[WARNING] $amountResults entries between $($currentStart) and $($currentEnd) exceeding the maximum of 5000 of entries" -Color "Red"
+							Write-LogFile -Message "[WARNING] $amountResults entries between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) exceeding the maximum of 5000 of entries" -Color "Red"
 							Write-LogFile -Message "[INFO] Temporary lowering time interval to $Interval minutes" -Color "Yellow"
 						}
 					}
@@ -575,14 +575,14 @@ function Get-UALSpecific
 							continue
 						}
 						else {
-							Write-LogFile -Message "No audit logs between $($currentStart) and $($currentEnd)"
+							Write-LogFile -Message "No audit logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))"
 							break
 						}
 					}
 							
 					$currentTotal = $results[0].ResultCount
 					$currentCount = $currentCount + $results.Count
-					Write-LogFile -Message "[INFO] Found $currentTotal audit logs between $($currentStart) and $($currentEnd)" -Color "Green"
+					Write-LogFile -Message "[INFO] Found $currentTotal audit logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Green"
 
 					if ($currentTotal -eq $results[$results.Count - 1].ResultIndex) {
 						$message = "[INFO] Successfully retrieved $($currentCount) records out of total $($currentTotal) for the current time range. Moving on!"

--- a/Scripts/Get-UALStatistics.ps1
+++ b/Scripts/Get-UALStatistics.ps1
@@ -65,7 +65,7 @@ function Get-UALStatistics
 	Set-Content $outputDirectory -Value "RecordType,Amount of log entries"
 
 	#Write-Host "[INFO] Calculating the number of audit logs" -ForegroundColor Green
-	Write-LogFile -Message "[INFO] Calculating the number of audit logs for each of the 236 Record Types" -Color "Green"
+	Write-LogFile -Message "[INFO] Calculating the number of audit logs for each of the 236 Record Types between $($script:StartDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK")) and $($script:EndDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Green"
 	$totalCount = Search-UnifiedAuditLog -Userids $UserIds -StartDate $script:StartDate -EndDate $script:EndDate -ResultSize 1 |  Format-List -Property ResultCount| out-string -Stream | select-string ResultCount
 	
 	Foreach ($record in $recordTypes) {


### PR DESCRIPTION
PR for issue #14.

Additionally update `StartDate`, `EndDate`, `StartDateMTL`, and `EndDateMTL` functions to alway return a DateTime object. Currently, when no start or end timestamps are provided, the functions return a timestamp as a string with no timezone information. As a result, the initial timestamp is retrieved in `UTC` (`[datetime]::Now.ToUniversalTime()`) but later implicitly converted using the system local timezone. 