### PR TITLE
Update Get-AzureADLogs.ps1

### DIFF
--- a/Scripts/Get-AzureADLogs.ps1
+++ b/Scripts/Get-AzureADLogs.ps1
@@ -119,7 +119,7 @@ function Get-ADAuditLogs {
 	)
 
 	try {
-		$areYouConnected = Get-AzureADAuditSignInLogs -ErrorAction stop
+		$areYouConnected = Get-AzureADAuditDirectoryLogs -ErrorAction stop
 	}
 	catch {
 		Write-logFile -Message "[WARNING] You must call Connect-Azure before running this script" -Color "Red"


### PR DESCRIPTION
Change Test for "Get-ADAuditLogs" to "Get-AzureADAuditDirectoryLogs" to account for sites without Azure AD Premium or B2C licensing.