### PR TITLE
Fix JSON Error in Get-AzureActivityLogs

### DIFF
--- a/Scripts/Get-AzureActivityLogs.ps1
+++ b/Scripts/Get-AzureActivityLogs.ps1
@@ -173,7 +173,7 @@ function Get-ActivityLogs {
 							
 							$backup = $tempInterval
 							$tempStartDate = $tempStartDate.AddHours($tempInterval)
-							$amountResults = Get-AzActivityLog -StartTime $tempStartDate -EndTime $currentEnd -MaxRecord 1000 -WarningAction SilentlyContinue 
+							$amountResults = Get-AzActivityLog -StartTime $tempStartDate -EndTime $currentEnd -MaxRecord 1000 -WarningAction SilentlyContinue
 						}
 						
 						$amountResults = Get-AzActivityLog -StartTime $tempStartDate -EndTime $currentEnd -MaxRecord 1000 -WarningAction SilentlyContinue

--- a/Scripts/Get-AzureActivityLogs.ps1
+++ b/Scripts/Get-AzureActivityLogs.ps1
@@ -173,13 +173,13 @@ function Get-ActivityLogs {
 							
 							$backup = $tempInterval
 							$tempStartDate = $tempStartDate.AddHours($tempInterval)
-							$amountResults = Get-AzActivityLog -StartTime $tempStartDate -EndTime $currentEnd -MaxRecord 1000 -WarningAction SilentlyContinue
+							$amountResults = Get-AzActivityLog -StartTime $tempStartDate -EndTime $currentEnd -MaxRecord 1000 -WarningAction SilentlyContinue 
 						}
 						
 						$amountResults = Get-AzActivityLog -StartTime $tempStartDate -EndTime $currentEnd -MaxRecord 1000 -WarningAction SilentlyContinue
 						Write-LogFile -Message "[INFO] Successfully retrieved $($amountResults.count) Activity logs between $tempStartDate and $currentEnd" -Color "Green"
 
-						$amountResults | Out-File -FilePath $filePath -Append -Encoding $Encoding
+						$amountResults | Select-Object EventTimestamp,EventName,EventDataId,TenantId,CorrelationId,SubStatus,SubscriptionId,SubmissionTimestamp,Status,ResourceType,ResourceProviderName,ResourceId,ResourceGroupName,OperationName,OperationId,Level,Id,Description,Category,Caller, @{Name='Authorization';expression={$_.Authorization -join ";"}}, @{Name='Claim';expression={$_.Claims -join ";"}}, @{Name='HttpRequest';expression={$_.HttpRequest -join ";"}}, @{Name='Properties';expression={$_.Properties -join ";"}} | Convert-ToJSON -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
 						
 						if ($tempStartDate -eq $currentEnd) {
 							$timeLeft = ($currentEnd - $start).TotalHours							
@@ -192,7 +192,7 @@ function Get-ActivityLogs {
 				
 				else {
 					Write-LogFile -Message "[INFO] Successfully retrieved $($amountResults.count) Activity logs for $formattedDate. Moving on!" -Color "Green"
-					Get-AzActivityLog -StartTime $start -EndTime $end -MaxRecord 1000 -WarningAction silentlyContinue | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
+					Get-AzActivityLog -StartTime $start -EndTime $end -MaxRecord 1000 -WarningAction silentlyContinue | Select-Object EventTimestamp,EventName,EventDataId,TenantId,CorrelationId,SubStatus,SubscriptionId,SubmissionTimestamp,Status,ResourceType,ResourceProviderName,ResourceId,ResourceGroupName,OperationName,OperationId,Level,Id,Description,Category,Caller, @{Name='Authorization';expression={$_.Authorization -join ";"}}, @{Name='Claim';expression={$_.Claims -join ";"}}, @{Name='HttpRequest';expression={$_.HttpRequest -join ";"}}, @{Name='Properties';expression={$_.Properties -join ";"}} | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
 				}					
 			}
 			

--- a/Scripts/Get-AzureActivityLogs.ps1
+++ b/Scripts/Get-AzureActivityLogs.ps1
@@ -179,7 +179,7 @@ function Get-ActivityLogs {
 						$amountResults = Get-AzActivityLog -StartTime $tempStartDate -EndTime $currentEnd -MaxRecord 1000 -WarningAction SilentlyContinue
 						Write-LogFile -Message "[INFO] Successfully retrieved $($amountResults.count) Activity logs between $tempStartDate and $currentEnd" -Color "Green"
 
-						$amountResults | Select-Object EventTimestamp,EventName,EventDataId,TenantId,CorrelationId,SubStatus,SubscriptionId,SubmissionTimestamp,Status,ResourceType,ResourceProviderName,ResourceId,ResourceGroupName,OperationName,OperationId,Level,Id,Description,Category,Caller, @{Name='Authorization';expression={$_.Authorization -join ";"}}, @{Name='Claim';expression={$_.Claims -join ";"}}, @{Name='HttpRequest';expression={$_.HttpRequest -join ";"}}, @{Name='Properties';expression={$_.Properties -join ";"}} | Convert-ToJSON -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
+						$amountResults | Select-Object @{N='EventTimestamp';E={$_.EventTimestamp.ToString()}},EventName,EventDataId,TenantId,CorrelationId,SubStatus,SubscriptionId,SubmissionTimestamp,Status,ResourceType,ResourceProviderName,ResourceId,ResourceGroupName,OperationName,OperationId,Level,Id,Description,Category,Caller, @{Name='Authorization';expression={$_.Authorization -join ";"}}, @{Name='Claim';expression={$_.Claims -join ";"}}, @{Name='HttpRequest';expression={$_.HttpRequest -join ";"}}, @{Name='Properties';expression={$_.Properties -join ";"}} | Convert-ToJSON -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
 						
 						if ($tempStartDate -eq $currentEnd) {
 							$timeLeft = ($currentEnd - $start).TotalHours							
@@ -192,7 +192,7 @@ function Get-ActivityLogs {
 				
 				else {
 					Write-LogFile -Message "[INFO] Successfully retrieved $($amountResults.count) Activity logs for $formattedDate. Moving on!" -Color "Green"
-					Get-AzActivityLog -StartTime $start -EndTime $end -MaxRecord 1000 -WarningAction silentlyContinue | Select-Object EventTimestamp,EventName,EventDataId,TenantId,CorrelationId,SubStatus,SubscriptionId,SubmissionTimestamp,Status,ResourceType,ResourceProviderName,ResourceId,ResourceGroupName,OperationName,OperationId,Level,Id,Description,Category,Caller, @{Name='Authorization';expression={$_.Authorization -join ";"}}, @{Name='Claim';expression={$_.Claims -join ";"}}, @{Name='HttpRequest';expression={$_.HttpRequest -join ";"}}, @{Name='Properties';expression={$_.Properties -join ";"}} | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
+					Get-AzActivityLog -StartTime $start -EndTime $end -MaxRecord 1000 -WarningAction silentlyContinue | Select-Object @{N='EventTimestamp';E={$_.EventTimestamp.ToString()}},EventName,EventDataId,TenantId,CorrelationId,SubStatus,SubscriptionId,SubmissionTimestamp,Status,ResourceType,ResourceProviderName,ResourceId,ResourceGroupName,OperationName,OperationId,Level,Id,Description,Category,Caller, @{Name='Authorization';expression={$_.Authorization -join ";"}}, @{Name='Claim';expression={$_.Claims -join ";"}}, @{Name='HttpRequest';expression={$_.HttpRequest -join ";"}}, @{Name='Properties';expression={$_.Properties -join ";"}} | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
 				}					
 			}
 			


### PR DESCRIPTION
Fixed the JSON error in #51  - Noting it is non conformant with the Microsoft Schema.

![image](https://github.com/invictus-ir/Microsoft-Extractor-Suite/assets/18164137/84159134-005f-4100-9ed8-790493f3d196)

Tested with new changes on test tenancy looks to be successful looking at a side by side comparison of the first record, however items are spit with `\r\n` which may cause issues for those passing into log ingestion platforms.