### PR TITLE
Change  Get-ADSignInLogs to acquire by day

### DIFF
--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -38,6 +38,21 @@ Function StartDate
 	}
 }
 
+Function StartDateAz
+{
+	if (($startDate -eq "") -Or ($null -eq $startDate)) {
+		$script:StartDate = [datetime]::Now.ToUniversalTime().AddDays(-30)
+		write-LogFile -Message "[INFO] No start date provived by user setting the start date to: $($script:StartDate.ToString("yyyy-MM-dd"))" -Color "Yellow"
+	}
+	else
+	{
+		$script:startDate = $startDate -as [datetime]
+		if (!$script:startDate ) { 
+			write-LogFile -Message "[WARNING] Not A valid start date and time, make sure to use YYYY-MM-DD" -Color "Red"
+		} 
+	}
+}
+
 function EndDate
 {
 	if (($endDate -eq "") -Or ($null -eq $endDate)) {

--- a/Scripts/Get-AzureADLogs.ps1
+++ b/Scripts/Get-AzureADLogs.ps1
@@ -128,8 +128,8 @@ function Get-ADSignInLogs {
 			Write-LogFile -Message "[WARNING] Empty data set returned between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd")). Moving On!"				
 		}
 		else {					
-			$currentTotal = $currentCount + $results.Count
 			$currentCount = $results.Count
+   			$currentTotal = $currentCount + $results.Count
 			
 			Write-LogFile -Message "[INFO] Found $currentCount Directory Sign In Logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd"))" -Color "Green"
 				

--- a/Scripts/Get-AzureADLogs.ps1
+++ b/Scripts/Get-AzureADLogs.ps1
@@ -137,16 +137,16 @@ function Get-ADSignInLogs {
 			
 			Write-LogFile -Message "[INFO] Found $currentCount Directory Sign In Logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd"))" -Color "Green"
 				
-
+			$filePath = "$OutputDir\SignInLogs-$($CurrentStart.ToString("yyyyMMdd"))-$($CurrentEnd.ToString("yyyyMMdd"))"
 			$results | ConvertTo-Json -Depth 100 | Out-File -Append $filePath -Encoding $Encoding
 
-			Write-LogFile -Message "[INFO] Successfully retrieved $($currentCount) records out of total $($currentTotal) for the current time range."
-			[Array]$results = @()							
+			Write-LogFile -Message "[INFO] Successfully retrieved $($currentCount) records out of total $($currentTotal) for the current time range."							
 		}
+		[Array]$results = @()
 		$CurrentStart = $CurrentEnd
   		$currentDay++
 	}
-	Write-LogFile -Message "[INFO] Acquisition complete, check the $($filePath) directory for your files.." -Color "Green"		
+	Write-LogFile -Message "[INFO] Acquisition complete, check the $($OutputDir) directory for your files.." -Color "Green"		
 }
 
 function Get-ADAuditLogs {

--- a/Scripts/Get-AzureADLogs.ps1
+++ b/Scripts/Get-AzureADLogs.ps1
@@ -104,7 +104,7 @@ function Get-ADSignInLogs {
 
 	while ($currentStart -lt $script:EndDate) {			
 		$currentEnd = $currentStart.AddMinutes($Interval)  
-		$currentTries = 0       
+		$currentDay = 0       
 		if ($UserIds){
 			Write-LogFile -Message "[INFO] Collecting Directory Sign In logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd"))."
 			try{
@@ -129,7 +129,12 @@ function Get-ADSignInLogs {
 		}
 		else {					
 			$currentCount = $results.Count
-   			$currentTotal = $currentCount + $results.Count
+			if ($currentDay -ne 0){
+				$currentTotal = $currentCount + $results.Count
+			}
+			else {
+				$currentTotal = $currentCount 
+			}
 			
 			Write-LogFile -Message "[INFO] Found $currentCount Directory Sign In Logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd"))" -Color "Green"
 				
@@ -140,6 +145,7 @@ function Get-ADSignInLogs {
 			[Array]$results = @()							
 		}
 		$CurrentStart = $CurrentEnd
+  		$currentDay++
 	}
 	Write-LogFile -Message "[INFO] Acquisition complete, check the $($filePath) directory for your files.." -Color "Green"		
 }

--- a/Scripts/Get-AzureADLogs.ps1
+++ b/Scripts/Get-AzureADLogs.ps1
@@ -102,7 +102,7 @@ function Get-ADSignInLogs {
 		return
 	}
 
-		while ($currentStart -lt $script:EndDate) {			
+	while ($currentStart -lt $script:EndDate) {			
 		$currentEnd = $currentStart.AddMinutes($Interval)  
 		$currentTries = 0       
 		if ($UserIds){
@@ -136,7 +136,7 @@ function Get-ADSignInLogs {
 
 			$results | ConvertTo-Json -Depth 100 | Out-File -Append $filePath -Encoding $Encoding
 
-			Write-LogFile -Message "[INFO] Successfully retrieved $($currentCount) records out of total $($currentTotal) for the current time range." -Color "Green"
+			Write-LogFile -Message "[INFO] Successfully retrieved $($currentCount) records out of total $($currentTotal) for the current time range."
 			[Array]$results = @()							
 		}
 		$CurrentStart = $CurrentEnd

--- a/Scripts/Get-AzureADLogs.ps1
+++ b/Scripts/Get-AzureADLogs.ps1
@@ -35,36 +35,46 @@ function Get-ADSignInLogs {
     Get sign-in logs for the user Test@invictus-ir.com.
 
 	.EXAMPLE
-    Get-ADSignInLogs -Before 2023-04-12
+    Get-ADSignInLogs -endDate 2023-04-12
 	Get sign-in logs before 2023-04-12.
 
 	.EXAMPLE
-    Get-ADSignInLogs -After 2023-04-12
+    Get-ADSignInLogs -startDate 2023-04-12
 	Get sign-in logs after 2023-04-12.
 #>
 	[CmdletBinding()]
 	param(
-		[string]$After,
-		[string]$Before,
+		[string]$startDate,
+		[string]$endDate,
 		[string]$outputDir,
 		[string]$UserIds,
-		[string]$Encoding
+		[string]$Encoding,
+		[string]$Interval
 	)
 
 	try {
+		import-module AzureADPreview -force -ErrorAction stop
 		$areYouConnected = Get-AzureADAuditSignInLogs -ErrorAction stop
 	}
 	catch {
-		Write-logFile -Message "[WARNING] You must call Connect-Azure before running this script" -Color "Red"
+		Write-logFile -Message "[WARNING] You must call Connect-Azure or install AzureADPreview before running this script" -Color "Red"
 		break
 	}
 
 	Write-logFile -Message "[INFO] Running Get-AADSignInLogs" -Color "Green"
 
+	StartDateAz
+	EndDate
+
+	if ($Interval -eq "") {
+		$Interval = 1440
+		Write-LogFile -Message "[INFO] Setting the Interval to the default value of 1440"
+	}
+
 	if ($Encoding -eq "" ){
 		$Encoding = "UTF8"
 	}
-	
+
 	$date = [datetime]::Now.ToString('yyyyMMddHHmmss') 
 	if ($OutputDir -eq "" ){
 		$OutputDir = "Output\AzureAD\$date"
@@ -74,126 +84,64 @@ function Get-ADSignInLogs {
 		}
 	}
 
-	else {
-		if (Test-Path -Path $OutputDir) {
-			write-LogFile -Message "[INFO] Custom directory set to: $OutputDir"
-		}
-	
-		else {
-			write-Error "[Error] Custom directory invalid: $OutputDir exiting script" -ErrorAction Stop
-			write-LogFile -Message "[Error] Custom directory invalid: $OutputDir exiting script"
-		}
+	if ($UserIds){
+		Write-LogFile -Message "[INFO] UserID's eq $($UserIds)"
 	}
+
 
 	$filePath = "$OutputDir\SignInLogs.json"
+		
+	[DateTime]$currentStart = $script:StartDate
+	[DateTime]$currentEnd = $script:EndDate
+	[DateTime]$lastLog = $script:EndDate
 
-	if (($After -eq "") -and ($Before -eq "")) {
-		Write-logFile -Message "[INFO] Collecting the Azure Active Directory sign-in logs"
 
-		if ($Userids){
-			try{
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "UserPrincipalName eq '$Userids'"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
-			}
-			catch{
-				Start-Sleep -Seconds 20
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "UserPrincipalName eq '$Userids'"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
-			}
-		}
-		else{
-			try{
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
-			}
-			catch{
-				Start-Sleep -Seconds 20
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
-			}
-		}
+	Write-LogFile -Message "[INFO] Extracting all available Directory Sign In Logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd"))" -Color "Green"
+	if($currentStart -gt $script:EndDate){
+		Write-LogFile -Message "[ERROR] $($currentStart.ToString("yyyy-MM-dd")) is greather than $($script:EndDate.ToString("yyyy-MM-dd")) - are you sure you put in the correct year? Exiting!" -Color "Red"
+		return
 	}
 
-	elseif (($After -ne "") -and ($Before -eq "")) {
-		Write-logFile -Message "[INFO] Collecting the Azure Active Directory sign in logs on or after $After"
-
-		if ($Userids){
+		while ($currentStart -lt $script:EndDate) {			
+		$currentEnd = $currentStart.AddMinutes($Interval)  
+		$currentTries = 0       
+		if ($UserIds){
+			Write-LogFile -Message "[INFO] Collecting Directory Sign In logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd"))."
 			try{
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "UserPrincipalName eq '$Userids' and createdDateTime gt $After"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
+				[Array]$results =  Get-AzureADAuditSignInLogs -All $true -Filter "UserPrincipalName eq '$($Userids)' and createdDateTime lt $($currentEnd.ToString("yyyy-MM-dd")) and createdDateTime gt $($currentStart.ToString("yyyy-MM-dd"))"
 			}
 			catch{
 				Start-Sleep -Seconds 20
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "UserPrincipalName eq '$Userids' and createdDateTime gt $After"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
+				[Array]$results =  Get-AzureADAuditSignInLogs -All $true -Filter "UserPrincipalName eq '$($Userids)' and createdDateTime lt $($currentEnd.ToString("yyyy-MM-dd")) and createdDateTime gt $($currentStart.ToString("yyyy-MM-dd"))"
 			}
 		}
-		else{
+		else {
 			try{
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "createdDateTime gt $After"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
+				[Array]$results =  Get-AzureADAuditSignInLogs -All $true -Filter "createdDateTime lt $($currentEnd.ToString("yyyy-MM-dd")) and createdDateTime gt $($currentStart.ToString("yyyy-MM-dd"))"
 			}
 			catch{
 				Start-Sleep -Seconds 20
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "createdDateTime gt $After"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
+				[Array]$results =  Get-AzureADAuditSignInLogs -All $true -Filter "createdDateTime lt $($currentEnd.ToString("yyyy-MM-dd")) and createdDateTime gt $($currentStart.ToString("yyyy-MM-dd"))"
 			}
 		}
+		if ($null -eq $results -or $results.Count -eq 0) {
+			Write-LogFile -Message "[WARNING] Empty data set returned between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd")). Moving On!"				
+		}
+		else {					
+			$currentTotal = $currentCount + $results.Count
+			$currentCount = $results.Count
+			
+			Write-LogFile -Message "[INFO] Found $currentCount Directory Sign In Logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd"))" -Color "Green"
+				
+
+			$results | ConvertTo-Json -Depth 100 | Out-File -Append $filePath -Encoding $Encoding
+
+			Write-LogFile -Message "[INFO] Successfully retrieved $($currentCount) records out of total $($currentTotal) for the current time range." -Color "Green"
+			[Array]$results = @()							
+		}
+		$CurrentStart = $CurrentEnd
 	}
-
-	elseif (($Before -ne "") -and ($After -eq "")) {
-		Write-logFile -Message "[INFO] Collecting the Azure Active Directory sign in logs on or before $Before"
-		if ($Userids){
-			try{
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "UserPrincipalName eq '$Userids' and createdDateTime lt $Before"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
-			}
-			catch{
-				Start-Sleep -Seconds 20
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "UserPrincipalName eq '$Userids' and createdDateTime lt $Before"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
-			}
-		}
-		else{
-			try{
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "createdDateTime lt $Before"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
-			}
-			catch{
-				Start-Sleep -Seconds 20
-				$signInLogs = Get-AzureADAuditSignInLogs -All $true -Filter "createdDateTime lt $Before"
-				$signInLogs | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Encoding $Encoding
-
-				Write-logFile -Message "[INFO] Sign-in logs written to $filePath" -Color "Green"
-			}
-		}
-	}
-
-	else {
-		Write-logFile -Message "[WARNING] Please only provide a start date or end date" -Color "Red"
-	}
+	Write-LogFile -Message "[INFO] Acquisition complete, check the $($filePath) directory for your files.." -Color "Green"		
 }
 
 function Get-ADAuditLogs {

--- a/Scripts/Get-AzureADLogs.ps1
+++ b/Scripts/Get-AzureADLogs.ps1
@@ -94,7 +94,7 @@ function Get-ADSignInLogs {
 	[DateTime]$currentStart = $script:StartDate
 	[DateTime]$currentEnd = $script:EndDate
 	[DateTime]$lastLog = $script:EndDate
-
+	$currentDay = 0  
 
 	Write-LogFile -Message "[INFO] Extracting all available Directory Sign In Logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd"))" -Color "Green"
 	if($currentStart -gt $script:EndDate){
@@ -103,8 +103,7 @@ function Get-ADSignInLogs {
 	}
 
 	while ($currentStart -lt $script:EndDate) {			
-		$currentEnd = $currentStart.AddMinutes($Interval)  
-		$currentDay = 0       
+		$currentEnd = $currentStart.AddMinutes($Interval)       
 		if ($UserIds){
 			Write-LogFile -Message "[INFO] Collecting Directory Sign In logs between $($currentStart.ToUniversalTime().ToString("yyyy-MM-dd")) and $($currentEnd.ToUniversalTime().ToString("yyyy-MM-dd"))."
 			try{


### PR DESCRIPTION
**Problem**
The current iteration of Get-ADSignInLogs runs out of memory when acquiring larger Tenancies sign in logs. I also note on fresh Windows 10 and Windows 11 VM's sometimes the AzureAD Preview does not run without an explicit import when installed with clobber.

**Solution**
Using a similar logic to Get-Ual, I made it acquire the data for 24 hours and write out to a json file which appends, the array then clears and it moves to the next day

**Testing**
I accidentally used 2023 as the -endDate parameter which caught me out, so i added in an error message.

Outside of this I have tested acquisition from a large tenancy successfully, and done some limited fuzzing in the command line arguments.

**Notes**
@JoeyInvictus  I changed the parameters on this to use endDate and startDate as per the other modules and #57  as it made it easier to understand the interlinks between each of the individual modules. Unsure if we want update the docs, or include the  old parameters for backwards compatability?