### PR TITLE
Make AzureADGraphLogs log a bit more verbose

### DIFF
--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -82,7 +82,8 @@ function Write-LogFile([String]$message,$color)
         default  { [Console]::ResetColor() }
     }
 
-    Write-Host $message
+    [Console]::WriteLine($message)
+    [Console]::ResetColor()
     $logToWrite = [DateTime]::Now.ToString() + ": " + $message
     $logToWrite | Out-File -FilePath $LogFile -Append
 }

--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -82,8 +82,7 @@ function Write-LogFile([String]$message,$color)
         default  { [Console]::ResetColor() }
     }
 
-    [Console]::WriteLine($message)
-    [Console]::ResetColor()
+    Write-Host $message
     $logToWrite = [DateTime]::Now.ToString() + ": " + $message
     $logToWrite | Out-File -FilePath $LogFile -Append
 }

--- a/Scripts/Get-AzureADGraphLogs.ps1
+++ b/Scripts/Get-AzureADGraphLogs.ps1
@@ -101,7 +101,7 @@ function Get-ADSignInLogsGraph {
                 $filePath = Join-Path -Path $OutputDir -ChildPath "$($date)-SignInLogsGraph.json"
 
 				$responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
-				$$dates = $responseJson.value | ForEach-Object { [DateTime]::Parse($_.CreatedDateTime) } | Sort-Object
+				$dates = $responseJson.value | ForEach-Object { [DateTime]::Parse($_.CreatedDateTime) } | Sort-Object
                 $from =  $dates | Select-Object -First 1
                 $fromstr =  $from.ToString('yyyy-MM-ddTHH:mmZ')
                 $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-ddTHH:mmZ')

--- a/Scripts/Get-AzureADGraphLogs.ps1
+++ b/Scripts/Get-AzureADGraphLogs.ps1
@@ -99,8 +99,12 @@ function Get-ADSignInLogsGraph {
 				$date = [datetime]::Now.ToString('yyyyMMddHHmmss') 
                 $filePath = Join-Path -Path $OutputDir -ChildPath "$($date)-SignInLogsGraph.json"
 
-				$responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding		
-                Write-LogFile -Message "[INFO] Sign-in logs written to $filePath" -ForegroundColor Green
+				$responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
+				$dates = $responseJson.value | ForEach-Object { $_.CreatedDateTime } | Sort-Object
+                $from =  ($dates | Select-Object -First 1).ToString('yyyy-MM-dd')
+                $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-dd')
+                $count = ($responseJson.value | measure).Count
+                Write-LogFile -Message "[INFO] Sign-in logs written to $filePath ($count records between $from and $to)" -ForegroundColor Green
             }
             $apiUrl = $responseJson.'@odata.nextLink'
         } While ($apiUrl)
@@ -216,8 +220,12 @@ function Get-ADAuditLogsGraph {
 			if ($responseJson.value) {
 				$date = [datetime]::Now.ToString('yyyyMMddHHmmss') 
 				$filePath = Join-Path -Path $OutputDir -ChildPath "$($date)-AuditLogs.json"
-                $responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding			
-				Write-LogFile -Message "[INFO] Audit logs written to $filePath" -ForegroundColor Green
+                $responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
+                $dates = $responseJson.value | ForEach-Object { $_.activityDateTime } | Sort-Object
+                $from =  ($dates | Select-Object -First 1).ToString('yyyy-MM-dd')
+                $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-dd')
+                $count = ($responseJson.value | measure).Count
+				Write-LogFile -Message "[INFO] Audit logs written to $filePath ($count records between $from and $to))" -ForegroundColor Green
 			} 
 			$apiUrl = $responseJson.'@odata.nextLink'
 		} While ($apiUrl)

--- a/Scripts/Get-AzureADGraphLogs.ps1
+++ b/Scripts/Get-AzureADGraphLogs.ps1
@@ -101,8 +101,8 @@ function Get-ADSignInLogsGraph {
 
 				$responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
 				$dates = $responseJson.value | ForEach-Object { $_.CreatedDateTime } | Sort-Object
-                $from =  ($dates | Select-Object -First 1).ToString('yyyy-MM-dd')
-                $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-dd')
+                $from =  ($dates | Select-Object -First 1).ToString('yyyy-MM-ddTHH:mmZ')
+                $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-ddTHH:mmZ')
                 $count = ($responseJson.value | measure).Count
                 Write-LogFile -Message "[INFO] Sign-in logs written to $filePath ($count records between $from and $to)" -ForegroundColor Green
             }
@@ -222,8 +222,8 @@ function Get-ADAuditLogsGraph {
 				$filePath = Join-Path -Path $OutputDir -ChildPath "$($date)-AuditLogs.json"
                 $responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
                 $dates = $responseJson.value | ForEach-Object { $_.activityDateTime } | Sort-Object
-                $from =  ($dates | Select-Object -First 1).ToString('yyyy-MM-dd')
-                $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-dd')
+                $from =  ($dates | Select-Object -First 1).ToString('yyyy-MM-ddTHH:mmZ')
+                $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-ddTHH:mmZ')
                 $count = ($responseJson.value | measure).Count
 				Write-LogFile -Message "[INFO] Audit logs written to $filePath ($count records between $from and $to))" -ForegroundColor Green
 			} 

--- a/Scripts/Get-AzureADGraphLogs.ps1
+++ b/Scripts/Get-AzureADGraphLogs.ps1
@@ -106,7 +106,7 @@ function Get-ADSignInLogsGraph {
                 $fromstr =  $from.ToString('yyyy-MM-ddTHH:mmZ')
                 $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-ddTHH:mmZ')
                 $count = ($responseJson.value | measure).Count
-                Write-LogFile -Message "[INFO] Sign-in logs written to $filePath ($count records between $fromstr and $to)" -ForegroundColor Green
+                Write-Host "[INFO] Sign-in logs written to $filePath ($count records between $fromStr and $to)" -ForegroundColor Green 
 
 			    $progress = [Math]::Round(($script:EndDate-$from).Ticks / $TotalTicks * 100, 2)
                 Write-Progress -Activity "Collecting Sign-in logs" -Status "$progress% Complete" -PercentComplete $progress
@@ -232,7 +232,7 @@ function Get-ADAuditLogsGraph {
                 $fromstr =  $from.ToString('yyyy-MM-ddTHH:mmZ')
                 $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-ddTHH:mmZ')
                 $count = ($responseJson.value | measure).Count
-				Write-LogFile -Message "[INFO] Audit logs written to $filePath ($count records between $fromstr and $to)" -ForegroundColor Green
+    				Write-Host "[INFO] Audit logs written to $filePath ($count records between $fromstr and $to)" -ForegroundColor Green 
 
 			    $progress = [Math]::Round(($script:EndDate-$from).Ticks / $TotalTicks * 100, 2)
                 Write-Progress -Activity "Collecting Audit logs" -Status "$progress% Complete" -PercentComplete $progress

--- a/Scripts/Get-AzureADGraphLogs.ps1
+++ b/Scripts/Get-AzureADGraphLogs.ps1
@@ -101,7 +101,7 @@ function Get-ADSignInLogsGraph {
                 $filePath = Join-Path -Path $OutputDir -ChildPath "$($date)-SignInLogsGraph.json"
 
 				$responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
-				$dates = $responseJson.value | ForEach-Object { $_.CreatedDateTime } | Sort-Object
+				$$dates = $responseJson.value | ForEach-Object { [DateTime]::Parse($_.CreatedDateTime) } | Sort-Object
                 $from =  $dates | Select-Object -First 1
                 $fromstr =  $from.ToString('yyyy-MM-ddTHH:mmZ')
                 $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-ddTHH:mmZ')
@@ -227,12 +227,12 @@ function Get-ADAuditLogsGraph {
 				$date = [datetime]::Now.ToString('yyyyMMddHHmmss') 
 				$filePath = Join-Path -Path $OutputDir -ChildPath "$($date)-AuditLogs.json"
                 $responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
-                $dates = $responseJson.value | ForEach-Object { $_.activityDateTime } | Sort-Object
+                $dates = $responseJson.value | ForEach-Object { [DateTime]::Parse($_.activityDateTime) } | Sort-Object
                 $from =  $dates | Select-Object -First 1
                 $fromstr =  $from.ToString('yyyy-MM-ddTHH:mmZ')
                 $to = ($dates | Select-Object -Last 1).ToString('yyyy-MM-ddTHH:mmZ')
                 $count = ($responseJson.value | measure).Count
-				Write-LogFile -Message "[INFO] Audit logs written to $filePath ($count records between $fromstr and $to))" -ForegroundColor Green
+				Write-LogFile -Message "[INFO] Audit logs written to $filePath ($count records between $fromstr and $to)" -ForegroundColor Green
 
 			    $progress = [Math]::Round(($script:EndDate-$from).Ticks / $TotalTicks * 100, 2)
                 Write-Progress -Activity "Collecting Audit logs" -Status "$progress% Complete" -PercentComplete $progress


### PR DESCRIPTION
Currently both commandlets within the AzureADGraphLogs (Sign-in and Audit) keep logging that they created a file. However, this doesn't give you any information about how long you can expect it to run. This PR adds a part to the log which indicates the amount of records, and the timeframe of records that have just been written to disk. This allows you to better see progress, and have an idea how much still needs to be collected.

Furthermore, since we now know which timeframe we have collected, and which still need to be processed we can calculate progress. So I've also added a little progress bar which shows the percentage