### PR TITLE
Fixed system.object[] strings written to MFA-UserRegistrationDetails.csv

### DIFF
--- a/Scripts/Get-MFAStatus.ps1
+++ b/Scripts/Get-MFAStatus.ps1
@@ -212,13 +212,18 @@ function Get-MFA {
         $nextLink = $response.'@odata.nextLink'
 
         ForEach ($detail in $userDetails) {
-          if (!$UserIds -or $UserIds -contains $detail.userPrincipalName) {
-            $myObject = [PSCustomObject]@{}
-            $detail.PSObject.Properties | ForEach-Object {
-                $myObject | Add-Member -Type NoteProperty -Name $_.Name -Value $_.Value
+            if (!$UserIds -or $UserIds -contains $detail.userPrincipalName) {
+                $myObject = [PSCustomObject]@{}
+                $detail.PSObject.Properties | ForEach-Object {
+                    $value = if ($_.Value -is [System.Array]) {
+                        ($_.Value -join ', ')
+                    } else {
+                        $_.Value
+                    }
+                    $myObject | Add-Member -Type NoteProperty -Name $_.Name -Value $value
+                }
+                $results += $myObject
             }
-            $results += $myObject
-          }
         }
     } while ($nextLink)
 


### PR DESCRIPTION
Running Get-MFA using module v2.1.1 returns a *-MFA-UserRegistrationDetails.csv file with methodsRegistered and systemPreferredAuthenticationMethods columns full of "system.object[]" instead of actual data. Reviewing the related code in Get-MFAStatus.ps1 found the methodsRegistered and systemPreferredAuthenticationMethods are both system.object[] converted to system.array[] by a ForEach statement but were never converted to strings to be piped to the Export-CSV. Added a join converting system.array[] objects to strings which properly populates all MFA-UserRegistrationDetails.csv columns.