### PR TITLE
Add output option for sof-elk in Get-UAL cmdlets 

### DIFF
--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -191,6 +191,10 @@ function Merge-OutputFiles {
 			Get-ChildItem $OutputDir -Filter *.csv | Select-Object -ExpandProperty FullName | Import-Csv | Export-Csv $mergedPath -NoTypeInformation -Append -Encoding UTF8
             Write-LogFile -Message "[INFO] CSV files merged into $mergedPath"
         }
+        'JSON-ELK' {
+			Get-ChildItem $OutputDir -Filter *.json | Select-Object -ExpandProperty FullName | ForEach-Object { Get-Content -Path $_ } | Out-File -Append $mergedPath -Encoding UTF8 
+            Write-LogFile -Message "[INFO] JSON-ELK files merged into $mergedPath"
+        }
         'JSON' {
             "[" | Set-Content $mergedPath -Encoding UTF8
 

--- a/docs/source/functionality/UnifiedAuditLog.rst
+++ b/docs/source/functionality/UnifiedAuditLog.rst
@@ -110,11 +110,12 @@ Parameters
     - Default: 60 minutes
 
 -Output (optional)
-    - Output is the parameter specifying the CSV or JSON output type.
+    - Output is the parameter specifying the CSV, JSON or JSON-ELK output type.
+    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
     - Default: CSV
 
 -MergeOutput (optional)
-    - MergeOutput is the parameter specifying if you wish to merge CSV outputs to a single file.
+    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or JSON-ELK outputs to a single file.
 
 -OutputDir (optional)
     - OutputDir is the parameter specifying the output directory.
@@ -269,11 +270,12 @@ Parameters
     - Default: 60 minutes
 
 -Output (optional)
-    - Output is the parameter specifying the CSV or JSON output type.
+    - Output is the parameter specifying the CSV, JSON or JSON-ELK output type.
+    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
     - Default: CSV
 
 -MergeOutput (optional)
-    - MergeOutput is the parameter specifying if you wish to merge CSV outputs to a single file.
+    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or JSON-ELK outputs to a single file.
 
 -OutputDir (optional)
     - OutputDir is the parameter specifying the output directory.
@@ -352,11 +354,12 @@ Parameters
     - Default: 60 minutes
 
 -Output (optional)
-    - Output is the parameter specifying the CSV or JSON output type.
+    - Output is the parameter specifying the CSV, JSON or JSON-ELK output type.
+    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
     - Default: CSV
 
 -MergeOutput (optional)
-    - MergeOutput is the parameter specifying if you wish to merge CSV outputs to a single file.
+    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or JSON-ELK outputs to a single file.
 
 -OutputDir (optional)
     - OutputDir is the parameter specifying the output directory.
@@ -667,14 +670,15 @@ Parameters
     - Default: Now
 
 -MergeOutput (optional)
-    - MergeOutput is the parameter specifying if you wish to merge CSV outputs to a single file.
+    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or JSON-ELK outputs to a single file.
 
 -Interval (optional)
     - Interval is the parameter specifying the interval in which the logs are being gathered.
     - Default: 60 minutes
 
 -Output (optional)
-    - Output is the parameter specifying the CSV or JSON output type.
+    - Output is the parameter specifying the CSV, JSON or JSON-ELK output type.
+    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
     - Default: CSV
 
 -OutputDir (optional)


### PR DESCRIPTION
This pull-request implements the `JSON-ELK` output option for the `Get-UAL` cmdlets. Files generated using the output format can be seamlessly imported into [sof-elk](https://github.com/philhagen/sof-elk). This is currently not trivially possible with data from the JSON output type from `Get-UAL` cmdlets, as they produce a single JSON document instead of a json file in the NDJSON format. This patch extracts the `AuditData` element and writes each `AuditData` element and saves it in NDJSON.

This implements the feature requested in https://github.com/invictus-ir/Microsoft-Extractor-Suite/issues/110.

Documentation and support for the `-MergeOutput` argument has been added as well.