### PR TITLE
Add output option for sof-elk in Get-ADSignInLogsGraph cmdlet

### DIFF
--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -192,7 +192,7 @@ function Merge-OutputFiles {
             Write-LogFile -Message "[INFO] CSV files merged into $mergedPath"
         }
         'JSON-ELK' {
-			Get-ChildItem $OutputDir -Filter *.json | Select-Object -ExpandProperty FullName | ForEach-Object { Get-Content -Path $_ } | Out-File -Append $mergedPath -Encoding UTF8 
+			Get-ChildItem $OutputDir -Filter *.json | Select-Object -ExpandProperty FullName | ForEach-Object { Get-Content -Path $_ | Where-Object { $_.Trim() -ne "" } } | Out-File -Append $mergedPath -Encoding UTF8 
             Write-LogFile -Message "[INFO] JSON-ELK files merged into $mergedPath"
         }
         'JSON' {

--- a/docs/source/functionality/AzureSignInLogsGraph.rst
+++ b/docs/source/functionality/AzureSignInLogsGraph.rst
@@ -19,6 +19,11 @@ Get the Azure Active Directory Audit Log after 2023-04-12:
 
    Get-ADSignInLogsGraph -startDate 2023-04-12
 
+Get the Azure Active Directory SignIn Log in a sof-elk format and merge all data into a single file:
+::
+
+   Get-ADSignInLogsGraph -Output JSON-ELK -MergeOutput
+
 Parameters
 """"""""""""""""""""""""""
 -startDate (optional)
@@ -26,6 +31,11 @@ Parameters
 
 -endDate (optional)
     - endDate is the parameter specifying the end date of the date range.
+
+-Output (optional)
+    - Output is the parameter specifying the JSON or JSON-ELK output type.
+    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
+    - Default: JSON
 
 -OutputDir (optional)
     - OutputDir is the parameter specifying the output directory.


### PR DESCRIPTION
I added the `-Output` option with the allowed values `JSON` (default) and `JSON-ELK` to the `Get-ADSignInLogsGraph` cmdlet. `JSON-ELK` will return JSON in the `NDJSON` format. Futhermore, I added a bugfix for the `-MergeOutput` functionality, which eliminated the newlines in my testing. A pull-request was opened in the [sof-elk](https://github.com/philhagen/sof-elk) repository which includes the required modifications, so that the logs can be imported into `sof-elk`.
Documentation and support for the `-MergeOutput` argument has been added as well.