### PR TITLE
migrate naming from "JSON-ELK" to "SOF-ELK" and adjust corresponding wording

### DIFF
--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -191,9 +191,9 @@ function Merge-OutputFiles {
 			Get-ChildItem $OutputDir -Filter *.csv | Select-Object -ExpandProperty FullName | Import-Csv | Export-Csv $mergedPath -NoTypeInformation -Append -Encoding UTF8
             Write-LogFile -Message "[INFO] CSV files merged into $mergedPath"
         }
-        'JSON-ELK' {
+        'SOF-ELK' {
 			Get-ChildItem $OutputDir -Filter *.json | Select-Object -ExpandProperty FullName | ForEach-Object { Get-Content -Path $_ | Where-Object { $_.Trim() -ne "" } } | Out-File -Append $mergedPath -Encoding UTF8 
-            Write-LogFile -Message "[INFO] JSON-ELK files merged into $mergedPath"
+            Write-LogFile -Message "[INFO] SOF-ELK files merged into $mergedPath"
         }
         'JSON' {
             "[" | Set-Content $mergedPath -Encoding UTF8

--- a/Scripts/Get-AzureADGraphLogs.ps1
+++ b/Scripts/Get-AzureADGraphLogs.ps1
@@ -17,7 +17,7 @@ function Get-ADSignInLogsGraph {
 	Default: No
 
 	.PARAMETER Output
-    Output is the parameter specifying the JSON or JSON-ELK output type. The JSON-ELK output can be imported into the sof-elk project.
+    Output is the parameter specifying the JSON or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
 	Default: JSON
 
     .PARAMETER OutputDir
@@ -48,8 +48,8 @@ function Get-ADSignInLogsGraph {
     Get audit logs after 2023-04-12.
 
 	.EXAMPLE
-    Get-ADSignInLogsGraph -Output JSON-ELK -MergeOutput
-    Get the Azure Active Directory SignIn Log in a sof-elk format and merge all data into a single file.
+    Get-ADSignInLogsGraph -Output SOF-ELK -MergeOutput
+    Get the Azure Active Directory SignIn Log in a format compatible with the SOF-ELK platform and merge all data into a single file.
 #>
     [CmdletBinding()]
     param(
@@ -111,8 +111,8 @@ function Get-ADSignInLogsGraph {
 				{
 					$responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding	
 				} 
-				elseif ($Output -eq "JSON-ELK"){
-					# UTF8 is fixed, as it is required by sof-elk
+				elseif ($Output -eq "SOF-ELK"){
+					# UTF8 is fixed, as it is required by SOF-ELK
 					foreach ($item in $responseJson.value) {
 						$item | ConvertTo-Json -Depth 100 -Compress | Out-File -FilePath $filePath -Append -Encoding UTF8	
 					}
@@ -140,9 +140,9 @@ function Get-ADSignInLogsGraph {
 		Write-LogFile -Message "[INFO] Merging output files into one file"
 		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON" -MergedFileName "SignInLogs-Combined.json"
 	}
-	elseif ($Output -eq "JSON-ELK" -and ($MergeOutput.IsPresent)) {
+	elseif ($Output -eq "SOF-ELK" -and ($MergeOutput.IsPresent)) {
 		Write-LogFile -Message "[INFO] Merging output files into one file"
-		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON-ELK" -MergedFileName "SignInLogs-Combined.json"
+		Merge-OutputFiles -OutputDir $OutputDir -OutputType "SOF-ELK" -MergedFileName "SignInLogs-Combined.json"
 	}
 
 	Write-LogFile -Message "[INFO] Acquisition complete, check the $($OutputDir) directory for your files.." -Color "Green"		

--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -27,7 +27,7 @@ function Get-UALAll
 	Default: 720 minutes
 
 	.PARAMETER Output
-    Output is the parameter specifying the CSV, JSON or JSON-ELK output type. The JSON-ELK output can be imported into the sof-elk project.
+    Output is the parameter specifying the CSV, JSON, or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
 	Default: CSV
 
 	.PARAMETER OutputDir
@@ -35,7 +35,7 @@ function Get-UALAll
 	Default: Output\UnifiedAuditLog
 
  	.PARAMETER MergeOutput
-    MergeOutput is the parameter specifying if you wish to merge CSV/JSON/JSON-ELK outputs to a single file.
+    MergeOutput is the parameter specifying if you wish to merge CSV/JSON/SOF-ELK outputs to a single file.
 
 	.PARAMETER Encoding
     Encoding is the parameter specifying the encoding of the CSV/JSON output file.
@@ -204,7 +204,7 @@ function Get-UALAll
 					if ($currentTotal -eq $results[$results.Count - 1].ResultIndex) {
 						$message = "[INFO] Successfully retrieved $($currentCount) records out of total $($currentTotal) for the current time range. Moving on!"
 						
-						if ($Output -eq "JSON" -or $Output -eq "JSON-ELK")
+						if ($Output -eq "JSON" -or $Output -eq "SOF-ELK")
 						{
 							$results = $results | ForEach-Object {
 								$_.AuditData = $_.AuditData | ConvertFrom-Json
@@ -217,7 +217,7 @@ function Get-UALAll
 								$json = $results | ConvertTo-Json -Depth 100
 								$json | Out-File -Append "$OutputDir/UAL-$sessionID.json" -Encoding $Encoding
 							} 
-							elseif ($Output -eq "JSON-ELK"){
+							elseif ($Output -eq "SOF-ELK"){
 								# Converts the JSON structure [{"AuditData":[data1],...},{"AuditData":[data2],...},...] to [[data1],[data2],...] with one data object per line in the final .json file.
 								# Encoding is hard-coded to UTF8 as UTF16 causes problems when importing the data into SOF-ELK
 								foreach ($item in $results) {
@@ -248,9 +248,9 @@ function Get-UALAll
 		Write-LogFile -Message "[INFO] Merging output files into one file"
 		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON" -MergedFileName "UAL-Combined.json"
 	}
-	elseif ($Output -eq "JSON-ELK" -and ($MergeOutput.IsPresent)) {
+	elseif ($Output -eq "SOF-ELK" -and ($MergeOutput.IsPresent)) {
 		Write-LogFile -Message "[INFO] Merging output files into one file"
-		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON-ELK" -MergedFileName "UAL-Combined.json"
+		Merge-OutputFiles -OutputDir $OutputDir -OutputType "SOF-ELK" -MergedFileName "UAL-Combined.json"
 	}
 
 	Write-LogFile -Message "[INFO] Acquisition complete, check the Output directory for your files.." -Color "Green"
@@ -287,7 +287,7 @@ function Get-UALGroup
 	Options are: Exchange, Azure, Sharepoint, Skype and Defender
 
 	.PARAMETER Output
-    Output is the parameter specifying the CSV, JSON or JSON-ELK output type. The JSON-ELK output can be imported into the sof-elk project.
+    Output is the parameter specifying the CSV, JSON, or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
 	Default: CSV
 
 	.PARAMETER OutputDir
@@ -295,7 +295,7 @@ function Get-UALGroup
 	Default: Output\UnifiedAuditLog
  
  	.PARAMETER MergeOutput
-    MergeOutput is the parameter specifying if you wish to merge CSV/JSON/JSON-ELK outputs to a single file.
+    MergeOutput is the parameter specifying if you wish to merge CSV/JSON/SOF-ELK outputs to a single file.
     
 	.PARAMETER Encoding
     Encoding is the parameter specifying the encoding of the CSV/JSON output file.
@@ -504,7 +504,7 @@ function Get-UALGroup
 										$json = $results | ConvertTo-Json -Depth 100
 										$json | Out-File -Append "$OutputDir/UAL-$sessionID.json" -Encoding $Encoding
 									} 
-									elseif ($Output -eq "JSON-ELK"){
+									elseif ($Output -eq "SOF-ELK"){
 										# Converts the JSON structure [{"AuditData":[data1],...},{"AuditData":[data2],...},...] to [[data1],[data2],...] with one data object per line in the final .json file.
 										foreach ($item in $results) {
 												$item.AuditData | ConvertTo-Json -Compress -Depth 100 | Out-File -Append "$OutputDir/UAL-$sessionID.json" -Encoding UTF8
@@ -539,9 +539,9 @@ function Get-UALGroup
 		Write-LogFile -Message "[INFO] Merging output files into one file"
 		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON" -MergedFileName "UAL-Combined.json"
 	}
-	elseif ($Output -eq "JSON-ELK" -and ($MergeOutput.IsPresent)) {
+	elseif ($Output -eq "SOF-ELK" -and ($MergeOutput.IsPresent)) {
 		Write-LogFile -Message "[INFO] Merging output files into one file"
-		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON-ELK" -MergedFileName "UAL-Combined.json"
+		Merge-OutputFiles -OutputDir $OutputDir -OutputType "SOF-ELK" -MergedFileName "UAL-Combined.json"
 	}
 	
 	Write-LogFile -Message "[INFO] Acquisition complete, check the Output directory for your files.." -Color "Green"
@@ -578,7 +578,7 @@ function Get-UALSpecific
 	Options are: ExchangeItem, ExchangeAdmin, etc. A total of 236 RecordTypes are supported.
 
 	.PARAMETER Output
-    Output is the parameter specifying the CSV, JSON or JSON-ELK output type. The JSON-ELK output can be imported into the sof-elk project.
+    Output is the parameter specifying the CSV, JSON, or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
 	Default: CSV
 
 	.PARAMETER OutputDir
@@ -590,7 +590,7 @@ function Get-UALSpecific
 	Default: UTF8
 
   	.PARAMETER MergeOutput
-    MergeOutput is the parameter specifying if you wish to merge CSV/JSON/JSON-ELK outputs to a single file.
+    MergeOutput is the parameter specifying if you wish to merge CSV/JSON/SOF-ELK outputs to a single file.
 
 	.PARAMETER ObjecIDs 
     The ObjectIds parameter filters the log entries by object ID. The object ID is the target object that was acted upon, and depends on the RecordType and Operations values of the event.
@@ -776,7 +776,7 @@ function Get-UALSpecific
 									$json = $results | ConvertTo-Json -Depth 100
 									$json | Out-File -Append "$OutputDir/UAL-$sessionID.json" -Encoding $Encoding
 								} 
-								elseif ($Output -eq "JSON-ELK"){
+								elseif ($Output -eq "SOF-ELK"){
 									# Converts the JSON structure [{"AuditData":[data1],...},{"AuditData":[data2],...},...] to [[data1],[data2],...] with one data object per line in the final .json file.
 									foreach ($item in $results) {
 											$item.AuditData | ConvertTo-Json -Compress -Depth 100 | Out-File -Append "$OutputDir/UAL-$sessionID.json" -Encoding UTF8
@@ -811,9 +811,9 @@ function Get-UALSpecific
 		Write-LogFile -Message "[INFO] Merging output files into one file"
 		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON" -MergedFileName "UAL-Combined.json"
 	}
-	elseif ($Output -eq "JSON-ELK" -and ($MergeOutput.IsPresent)) {
+	elseif ($Output -eq "SOF-ELK" -and ($MergeOutput.IsPresent)) {
 		Write-LogFile -Message "[INFO] Merging output files into one file"
-		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON-ELK" -MergedFileName "UAL-Combined.json"
+		Merge-OutputFiles -OutputDir $OutputDir -OutputType "SOF-ELK" -MergedFileName "UAL-Combined.json"
 	}
 
 	Write-LogFile -Message "[INFO] Acquisition complete, check the Output directory for your files.." -Color "Green"
@@ -850,7 +850,7 @@ function Get-UALSpecificActivity
 	Options are: New-MailboxRule, MailItemsAccessed, etc. A total of 108 common ActivityTypes are supported.
 
 	.PARAMETER Output
-    Output is the parameter specifying the CSV, JSON or JSON-ELK output type. The JSON-ELK output can be imported into the sof-elk project.
+    Output is the parameter specifying the CSV, JSON, or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
 	Default: CSV
 
 	.PARAMETER OutputDir
@@ -1030,7 +1030,7 @@ function Get-UALSpecificActivity
 									$json = $results | ConvertTo-Json -Depth 100
 									$json | Out-File -Append "$OutputDir/UAL-$sessionID.json" -Encoding $Encoding
 								} 
-								elseif ($Output -eq "JSON-ELK"){
+								elseif ($Output -eq "SOF-ELK"){
 									# Converts the JSON structure [{"AuditData":[data1],...},{"AuditData":[data2],...},...] to [[data1],[data2],...] with one data object per line in the final .json file.
 									foreach ($item in $results) {
 											$item.AuditData | ConvertTo-Json -Compress -Depth 100 | Out-File -Append "$OutputDir/UAL-$sessionID.json" -Encoding UTF8
@@ -1064,9 +1064,9 @@ function Get-UALSpecificActivity
 		Write-LogFile -Message "[INFO] Merging output files into one file"
 		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON" -MergedFileName "UAL-Combined.json"
 	}
-	elseif ($Output -eq "JSON-ELK" -and ($MergeOutput.IsPresent)) {
+	elseif ($Output -eq "SOF-ELK" -and ($MergeOutput.IsPresent)) {
 		Write-LogFile -Message "[INFO] Merging output files into one file"
-		Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON-ELK" -MergedFileName "UAL-Combined.json"
+		Merge-OutputFiles -OutputDir $OutputDir -OutputType "SOF-ELK" -MergedFileName "UAL-Combined.json"
 	}
 
 	Write-LogFile -Message "[INFO] Acquisition complete, check the Output directory for your files.." -Color "Green"

--- a/docs/source/functionality/AzureSignInLogsGraph.rst
+++ b/docs/source/functionality/AzureSignInLogsGraph.rst
@@ -19,10 +19,10 @@ Get the Azure Active Directory Audit Log after 2023-04-12:
 
    Get-ADSignInLogsGraph -startDate 2023-04-12
 
-Get the Azure Active Directory SignIn Log in a sof-elk format and merge all data into a single file:
+Get the Azure Active Directory SignIn Log in a SOF-ELK format and merge all data into a single file:
 ::
 
-   Get-ADSignInLogsGraph -Output JSON-ELK -MergeOutput
+   Get-ADSignInLogsGraph -Output SOF-ELK -MergeOutput
 
 Parameters
 """"""""""""""""""""""""""
@@ -33,8 +33,8 @@ Parameters
     - endDate is the parameter specifying the end date of the date range.
 
 -Output (optional)
-    - Output is the parameter specifying the JSON or JSON-ELK output type.
-    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
+    - Output is the parameter specifying the JSON or SOF-ELK output type.
+    - The SOF-ELK output type can be used to export logs in a format suitable for the [platform of the same name](https://github.com/philhagen/sof-elk).
     - Default: JSON
 
 -OutputDir (optional)

--- a/docs/source/functionality/UnifiedAuditLog.rst
+++ b/docs/source/functionality/UnifiedAuditLog.rst
@@ -110,12 +110,12 @@ Parameters
     - Default: 60 minutes
 
 -Output (optional)
-    - Output is the parameter specifying the CSV, JSON or JSON-ELK output type.
-    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
+    - Output is the parameter specifying the CSV, JSON or SOF-ELK output type.
+    - The SOF-ELK output type can be used to export logs in a format suitable for the [platform of the same name](https://github.com/philhagen/sof-elk).
     - Default: CSV
 
 -MergeOutput (optional)
-    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or JSON-ELK outputs to a single file.
+    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or SOF-ELK outputs to a single file.
 
 -OutputDir (optional)
     - OutputDir is the parameter specifying the output directory.
@@ -270,12 +270,12 @@ Parameters
     - Default: 60 minutes
 
 -Output (optional)
-    - Output is the parameter specifying the CSV, JSON or JSON-ELK output type.
-    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
+    - Output is the parameter specifying the CSV, JSON or SOF-ELK output type.
+    - The SOF-ELK output type can be used to export logs in a format suitable for the [platform of the same name](https://github.com/philhagen/sof-elk).
     - Default: CSV
 
 -MergeOutput (optional)
-    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or JSON-ELK outputs to a single file.
+    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or SOF-ELK outputs to a single file.
 
 -OutputDir (optional)
     - OutputDir is the parameter specifying the output directory.
@@ -354,12 +354,12 @@ Parameters
     - Default: 60 minutes
 
 -Output (optional)
-    - Output is the parameter specifying the CSV, JSON or JSON-ELK output type.
-    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
+    - Output is the parameter specifying the CSV, JSON or SOF-ELK output type.
+    - The SOF-ELK output type can be used to export logs in a format suitable for the [platform of the same name](https://github.com/philhagen/sof-elk).
     - Default: CSV
 
 -MergeOutput (optional)
-    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or JSON-ELK outputs to a single file.
+    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or SOF-ELK outputs to a single file.
 
 -OutputDir (optional)
     - OutputDir is the parameter specifying the output directory.
@@ -670,15 +670,15 @@ Parameters
     - Default: Now
 
 -MergeOutput (optional)
-    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or JSON-ELK outputs to a single file.
+    - MergeOutput is the parameter specifying if you wish to merge CSV, JSON or SOF-ELK outputs to a single file.
 
 -Interval (optional)
     - Interval is the parameter specifying the interval in which the logs are being gathered.
     - Default: 60 minutes
 
 -Output (optional)
-    - Output is the parameter specifying the CSV, JSON or JSON-ELK output type.
-    - The JSON-ELK output type can be used to export logs in a [sof-elk](https://github.com/philhagen/sof-elk) compatible format.
+    - Output is the parameter specifying the CSV, JSON or SOF-ELK output type.
+    - The SOF-ELK output type can be used to export logs in a format suitable for the [platform of the same name](https://github.com/philhagen/sof-elk).
     - Default: CSV
 
 -OutputDir (optional)


### PR DESCRIPTION
This PR changes the terminology from `JSON-ELK` to `SOF-ELK`, which more accurately describes the use case.  "ELK" is a broader term and the output from these scripts is not universally suited to a generic Elastic Stack implementation.  Instead, the specific parsers in SOF-ELK itself align with their output.

I also adjusted some phrasing to better match the US trademark.  (These are admittedly cosmetic, but please forgive the occasional silliness of US copyright law and how we have to be consistent in order to retain certain IP rights.)