### PR TITLE
Adding CSV Output Command to Get-UALGraph

### DIFF
--- a/Scripts/Get-UALGraph.ps1
+++ b/Scripts/Get-UALGraph.ps1
@@ -211,7 +211,7 @@ Function Get-UALGraph {
                     $responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
                 }
 		elseif ($Output -eq "CSV") {
-  		    $responseJson.value | ConvertTo-Json -Depth 100 | Export-Csv -Path $filePath -Append -Encoding $Encoding -NoTypeInformation
+  		    $responseJson.value | Export-Csv -Path $filePath -Append -Encoding $Encoding -NoTypeInformation
                 }
             } else {
                 Write-logFile -Message "[INFO] No results matched your search." -color Yellow -Level Minimal


### PR DESCRIPTION
Like the other scripts where OUTPUT can be set to CSV, JSON..etc I have added this to the Get-UALGraph script.

The JSON output is unchanged and the ability to save a CSV has been added.   

The $responseJson.value can be directly exported as a CSV.