### PR TITLE
CSV Output Fix

### DIFF
--- a/Scripts/Get-UALGraph.ps1
+++ b/Scripts/Get-UALGraph.ps1
@@ -211,7 +211,7 @@ Function Get-UALGraph {
                     $responseJson.value | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding
                 }
 		elseif ($Output -eq "CSV") {
-  		    $responseJson.value | Export-Csv -Path $filePath -Append -Encoding $Encoding -NoTypeInformation
+                    $responseJson.value | Select-Object id, createdDateTime, auditLogRecordType, operation, organizationId, userType, userId, service, objectId, userPrincipalName, clientIp, administrativeUnits, @{Name = "auditData"; Expression = { $_.auditData | ConvertTo-Json -Depth 100 } } | Export-Csv -Path $filePath -Append -Encoding $Encoding -NoTypeInformation
                 }
             } else {
                 Write-logFile -Message "[INFO] No results matched your search." -color Yellow -Level Minimal


### PR DESCRIPTION
The auditData column was being truncated because it is a JSON object.  The code has been updated to save each column as is but export the auditData as a JSON with a Depth of 100 to make sure nothing is truncated.