### PR TITLE
UAL Only use ReturnLargeSet when needed

### DIFF
--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -539,8 +539,12 @@ function Get-UAL {
 											$totalProcessed = 0
 	
 											while ($totalProcessed -lt $amountResults) {
-												[Array]$results = Search-UnifiedAuditLog -StartDate $CurrentStart -EndDate $currentEnd -SessionCommand ReturnLargeSet -SessionId $sessionId -ResultSize $resultSize @baseSearchQuery
-												
+												if ($amountResults -gt 5000) {
+													[Array]$results = Search-UnifiedAuditLog -StartDate $CurrentStart -EndDate $currentEnd -SessionCommand ReturnLargeSet -SessionId $sessionId -ResultSize $resultSize @baseSearchQuery
+												} else {
+													[Array]$results = Search-UnifiedAuditLog -StartDate $CurrentStart -EndDate $currentEnd -ResultSize $resultSize @baseSearchQuery
+												}
+
 												if ($null -ne $results -and $results.Count -gt 0) {
 													$allResults += $results
 													$totalProcessed += $results.Count


### PR DESCRIPTION
Currently I have a case where the command `Get-UAL -StartDate "2025-05-12" -EndDate "2025-05-13" -MergeOutput` tries to fetch around 900 records. However, this keeps failing due to the use of the `ReturnLargeSet`, which makes that it never finishes. As soon as I remove that part it fetches the records correctly. This is also not needed when fetching less than 5000 records as far as I am aware of. So I have added a check that only applies this when fetching more than 5000 records.

I am currently not able to check this in a large environment, so if someone has the option to double check that it still works for large environments would be great!