### PR TITLE
Add debug logging to UAL and early exit for incorrect batches

### DIFF
--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -101,6 +101,7 @@ enum LogLevel {
     None     = 0
     Minimal  = 1
     Standard = 2
+    Debug    = 3
 }
 
 $script:LogLevel = [LogLevel]::Standard
@@ -119,7 +120,7 @@ function Write-LogFile {
     param(
         [Parameter(Mandatory=$true)]
         [string]$Message,
-        [string]$Color = "White",
+        [string]$Color,
         [switch]$NoNewLine,
         [LogLevel]$Level = [LogLevel]::Standard
     )
@@ -136,6 +137,10 @@ function Write-LogFile {
 	if (!(test-path $outputDir)) {
 		New-Item -ItemType Directory -Force -Name $Outputdir > $null
 	}
+
+    if(!$color -and $Level -eq [LogLevel]::Debug) {
+        $color = "Yellow"
+    }
 
 	switch ($color) {
         "Yellow" { [Console]::ForegroundColor = [ConsoleColor]::Yellow }

--- a/Scripts/Get-AdminAuditLog.ps1
+++ b/Scripts/Get-AdminAuditLog.ps1
@@ -60,7 +60,7 @@ function Get-AdminAuditLog {
         [string]$Output = "CSV",
         [switch]$MergeOutput,
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 

--- a/Scripts/Get-AllEvidence.ps1
+++ b/Scripts/Get-AllEvidence.ps1
@@ -528,7 +528,7 @@ function Start-EvidenceCollection {
         [ValidateSet('All', 'Azure', 'M365')]
         [string]$Platform = 'All',
         [Parameter(Mandatory=$false)]
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Minimal',
         [Parameter(Mandatory=$false)]
         [string]$UserIds,

--- a/Scripts/Get-AuditLogSettings.ps1
+++ b/Scripts/Get-AuditLogSettings.ps1
@@ -37,7 +37,7 @@ function Get-MailboxAuditStatus {
     param (
         [string]$OutputDir = "Output\Audit Status",
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard',
         [string]$UserIds
     )

--- a/Scripts/Get-AzureADGraphLogs.ps1
+++ b/Scripts/Get-AzureADGraphLogs.ps1
@@ -85,7 +85,7 @@ function Get-GraphEntraSignInLogs {
         [string]$UserIds,
 		[switch]$MergeOutput,
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard',
 		[Parameter()]
 		[ValidateSet('All', 'interactiveUser', 'nonInteractiveUser', 'servicePrincipal', 'managedIdentity')]
@@ -371,7 +371,7 @@ function Get-GraphEntraAuditLogs {
 		[switch]$MergeOutput,
 		[string]$UserIds,
         [switch]$All,
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
 	)
 

--- a/Scripts/Get-AzureADLogs.ps1
+++ b/Scripts/Get-AzureADLogs.ps1
@@ -63,7 +63,7 @@ function Get-EntraSignInLogs {
 			[switch]$MergeOutput,
 			[string]$Encoding = "UTF8",
 			[string]$Interval = 1440,
-			[ValidateSet('None', 'Minimal', 'Standard')]
+			[ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
 			[string]$LogLevel = 'Standard'
 		)
 	
@@ -244,7 +244,7 @@ function Get-EntraSignInLogs {
 			[switch]$MergeOutput,
 			[string]$Encoding = "UTF8",
 			[string]$Interval = 720,
-			[ValidateSet('None', 'Minimal', 'Standard')]
+			[ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
 			[string]$LogLevel = 'Standard'
 		)
 	

--- a/Scripts/Get-AzureActivityLogs.ps1
+++ b/Scripts/Get-AzureActivityLogs.ps1
@@ -57,7 +57,7 @@ function Get-ActivityLogs {
 		[string]$SubscriptionID,
 		[string]$OutputDir = "Output\ActivityLogs",
 		[string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'		
 	)
 

--- a/Scripts/Get-AzureDirectoryActivityLogs.ps1
+++ b/Scripts/Get-AzureDirectoryActivityLogs.ps1
@@ -53,7 +53,7 @@ function Get-DirectoryActivityLogs {
 		[string]$output = "CSV",
 		[string]$outputDir = "Output\DirectoryActivityLogs",
 		[string]$encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'	
 	)
 

--- a/Scripts/Get-ConditionalAccessPolicy.ps1
+++ b/Scripts/Get-ConditionalAccessPolicy.ps1
@@ -42,7 +42,7 @@ Function Get-ConditionalAccessPolicies {
     param(
         [string]$OutputDir = "Output\ConditionalAccessPolicies",
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 

--- a/Scripts/Get-Devices.ps1
+++ b/Scripts/Get-Devices.ps1
@@ -55,7 +55,7 @@ function Get-Devices {
         [string]$Encoding = "UTF8",
         [ValidateSet("CSV", "JSON")]
         [string]$Output = "CSV",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard',
         [string]$UserIds
     )

--- a/Scripts/Get-Emails.ps1
+++ b/Scripts/Get-Emails.ps1
@@ -55,7 +55,7 @@ Function Get-Email {
         [string]$outputDir = "Output\EmailExport",
         [switch]$attachment,
         [string]$inputFile,
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     ) 
 
@@ -285,7 +285,7 @@ Function Get-Attachment {
         [Parameter(Mandatory=$true)]$userIds,
         [Parameter(Mandatory=$true)]$internetMessageId,
         [string]$outputDir = "Output\EmailExport",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 
@@ -369,7 +369,7 @@ Function Show-Email {
     param(
         [Parameter(Mandatory=$true)]$userIds,
         [Parameter(Mandatory=$true)]$internetMessageId,
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 

--- a/Scripts/Get-Groups.ps1
+++ b/Scripts/Get-Groups.ps1
@@ -38,7 +38,7 @@ Function Get-Groups {
     param(
         [string]$OutputDir = "Output\Groups",
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 
@@ -146,7 +146,7 @@ Function Get-GroupMembers {
     param(
         [string]$OutputDir = "Output\Groups",
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 
@@ -236,7 +236,7 @@ Function Get-DynamicGroups {
     param(
         [string]$OutputDir = "Output\Groups",
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 

--- a/Scripts/Get-MFAStatus.ps1
+++ b/Scripts/Get-MFAStatus.ps1
@@ -46,7 +46,7 @@ function Get-MFA {
         [string]$OutputDir = "Output\MFA",
         [string]$Encoding = "UTF8",
         [string[]]$UserIds,
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 

--- a/Scripts/Get-MailItemsAccessed.ps1
+++ b/Scripts/Get-MailItemsAccessed.ps1
@@ -56,7 +56,7 @@ Function Get-Sessions {
 		[string]$Encoding = "UTF8",
         [ValidateSet("Yes", "No")]
         [string]$Output = "Yes",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
 	)
 
@@ -373,7 +373,7 @@ function Get-MessageIDs {
         [ValidateSet("Yes", "No")]
         [string]$Output = "Yes",
         [switch]$Download,
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
 	)
 

--- a/Scripts/Get-MailboxAuditLog.ps1
+++ b/Scripts/Get-MailboxAuditLog.ps1
@@ -66,7 +66,7 @@ function Get-MailboxAuditLog
         [string]$Output = "CSV",
         [switch]$MergeOutput,
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 
@@ -172,7 +172,7 @@ function Get-MailboxAuditLogLegacy
 		[string]$EndDate,
 		[string]$OutputDir = "Output\MailboxAuditLog",
 		[string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
 	)
 

--- a/Scripts/Get-MailboxPermissions.ps1
+++ b/Scripts/Get-MailboxPermissions.ps1
@@ -41,7 +41,7 @@ function Get-MailboxPermissions {
     param (
         [string]$outputDir = "Output\Delegated Permissions",
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard',
         [string]$UserIds
     )

--- a/Scripts/Get-MessageTraceLog.ps1
+++ b/Scripts/Get-MessageTraceLog.ps1
@@ -97,7 +97,7 @@ function Get-MessageTraceLog
 		[string]$EndDate,
 		[string]$OutputDir = "Output\MessageTrace",
 		[string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
 	)
 

--- a/Scripts/Get-OAuthPermissions.ps1
+++ b/Scripts/Get-OAuthPermissions.ps1
@@ -98,7 +98,7 @@ Lists delegated permissions (OAuth2PermissionGrants) and application permissions
 		[int] $PrecacheSize = 999,
 		[string] $OutputDir = "Output\OAuthPermissions",
 		[string] $Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
 	)
 
@@ -336,7 +336,7 @@ Default: Standard
         [switch] $ApplicationPermissions,
         [string] $OutputDir = "Output\OAuthPermissions",
         [string] $Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 

--- a/Scripts/Get-ProductLicenses.ps1
+++ b/Scripts/Get-ProductLicenses.ps1
@@ -24,7 +24,7 @@ Function Get-Licenses {
     [CmdletBinding()]
     param(
         [string]$OutputDir = "Output\Licenses",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 
@@ -117,7 +117,7 @@ Function Get-LicenseCompatibility {
 #>
     [CmdletBinding()]
     param(
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 
@@ -218,7 +218,7 @@ Function Get-EntraSecurityDefaults {
     [CmdletBinding()]
     param(
         [string]$OutputDir = "Output\Licenses",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 
@@ -341,7 +341,7 @@ Function Get-LicensesByUser {
     [CmdletBinding()]
     param(
         [string]$OutputDir = "Output\Licenses",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 

--- a/Scripts/Get-RiskyEvents.ps1
+++ b/Scripts/Get-RiskyEvents.ps1
@@ -46,7 +46,7 @@ function Get-RiskyUsers {
         [string]$OutputDir = "Output\RiskyEvents",
         [string]$Encoding = "UTF8",
         [string[]]$UserIds,
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 
@@ -233,7 +233,7 @@ function Get-RiskyDetections {
         [string]$OutputDir= "Output\RiskyEvents",
         [string]$Encoding = "UTF8",
         [string[]]$UserIds,
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 

--- a/Scripts/Get-Rules.ps1
+++ b/Scripts/Get-Rules.ps1
@@ -59,7 +59,7 @@ function Get-TransportRules
 	param (
 		[string]$OutputDir = "Output\Rules"	,
 		[string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
 	)
 
@@ -265,7 +265,7 @@ function Get-MailboxRules
 		[string]$UserIds,
 		[string]$OutputDir = "Output\Rules",
 		[string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
 	)
 

--- a/Scripts/Get-UALGraph.ps1
+++ b/Scripts/Get-UALGraph.ps1
@@ -108,7 +108,7 @@ Function Get-UALGraph {
         [string[]]$UserIds = @(),
         [string[]]$IPAddress = @(),
         [string[]]$ObjecIDs = @(),
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard',
         [double]$MaxEventsPerFile = 250000,
         [ValidateSet("CSV", "JSON", "SOF-ELK")]

--- a/Scripts/Get-UALStatistics.ps1
+++ b/Scripts/Get-UALStatistics.ps1
@@ -42,7 +42,7 @@ function Get-UALStatistics
 		[string]$StartDate,
 		[string]$EndDate,
 		[string]$OutputDir = "Output\",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
 	)
 

--- a/Scripts/Get-UsersInfo.ps1
+++ b/Scripts/Get-UsersInfo.ps1
@@ -43,7 +43,7 @@ function Get-Users {
         [string]$OutputDir = "Output\Users",
         [string]$Encoding = "UTF8",
         [string]$UserIds,
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 
@@ -214,7 +214,7 @@ Function Get-AdminUsers {
     param(
         [string]$outputDir = "Output\Admins",
         [string]$Encoding = "UTF8",
-        [ValidateSet('None', 'Minimal', 'Standard')]
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard'
     )
 


### PR DESCRIPTION
This PR adds another level of logging, `Debug`. I had a case where the script kept on a log line of `[INFO] Found x audit logs between x and x` for quite some time. This was caused by the retry mechanism, which is nice but we couldn't see this. By default this is fine, but for debugging reasons we want to see what the script is doing. 

Next to this I had a few cases where the script needed to fetch multiple records (something like 20K in 1 batch). However, the first fetch already returned < 5000 records. In that case we are quite sure that the end result is never gonna be correct. So the script now checks that every request within the retrieval of the max 50K records is correct, and if not it will do an early exit and retry the whole batch.