### PR TITLE
Add Support for JSONL Output Format 

### DIFF
--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -298,6 +298,22 @@ function Merge-OutputFiles {
             Write-LogFile -Message "[INFO] JSON files merged into $mergedPath"
             
         }
+        'JSONL' {
+            $jsonlFiles = Get-ChildItem -Path $OutputDir -Filter *.jsonl
+            if ($jsonlFiles.Count -eq 0) {
+                Write-LogFile -Message "[ERROR] No JSONL files found in the specified directory: $OutputDir" -Color Red
+                return
+            }
+
+            $mergedContent = @()
+            foreach ($file in $jsonlFiles) {
+                $content = Get-Content -Path $file.FullName -Raw
+                $mergedContent += $content.Trim()
+            }
+
+            Set-Content -Path $mergedPath -Value ($mergedContent -join "`n") -Encoding UTF8
+            Write-LogFile -Message "[INFO] JSONL files merged into $mergedPath"
+        }
         default {
             Write-LogFile -Message "[ERROR] Unsupported file type specified: $OutputType" -Color Red
         }

--- a/Scripts/Get-AdminAuditLog.ps1
+++ b/Scripts/Get-AdminAuditLog.ps1
@@ -17,7 +17,7 @@ function Get-AdminAuditLog {
     Interval is the parameter specifying the interval in which the logs are being gathered.
 
 	.PARAMETER Output
-    Output is the parameter specifying the CSV, JSON, or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
+    Output is the parameter specifying the CSV, JSON, JSONL or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
     Default: CSV
 
     .PARAMETER MergeOutput
@@ -56,7 +56,7 @@ function Get-AdminAuditLog {
         [string]$EndDate,
         [decimal]$Interval,
         [string]$OutputDir = "Output\AdminAuditLog",
-        [ValidateSet("CSV", "JSON", "SOF-ELK")]
+        [ValidateSet("CSV", "JSON", "SOF-ELK", "JSONL")]
         [string]$Output = "CSV",
         [switch]$MergeOutput,
         [string]$Encoding = "UTF8",

--- a/Scripts/Get-AllEvidence.ps1
+++ b/Scripts/Get-AllEvidence.ps1
@@ -506,7 +506,7 @@ function Start-EvidenceCollection {
     Optional. Comma-separated list of user IDs to filter the collection scope.
 
     .PARAMETER Output
-    Output is the parameter specifying the CSV, JSON, or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
+    Output is the parameter specifying the CSV, JSON, JSONL or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
 	Default: CSV
 
     .PARAMETER Interactive
@@ -535,7 +535,7 @@ function Start-EvidenceCollection {
         [Parameter(Mandatory=$false)]
         [switch]$Interactive,
         [Parameter(Mandatory=$false)]
-        [ValidateSet('CSV', 'JSON', 'SOF-ELK')]
+        [ValidateSet('CSV', 'JSON', 'SOF-ELK', "JSONL")]
         [string]$Output = 'CSV',
         [Parameter(Mandatory=$false)]
         [string]$OutputDir

--- a/Scripts/Get-AzureDirectoryActivityLogs.ps1
+++ b/Scripts/Get-AzureDirectoryActivityLogs.ps1
@@ -24,7 +24,7 @@ function Get-DirectoryActivityLogs {
 	Default: UTF8
 
     .PARAMETER Output
-    Output is the parameter specifying the CSV or JSON output type.
+    Output is the parameter specifying the CSV, JSONL or JSON output type.
 	Default: CSV
 
     .PARAMETER LogLevel
@@ -176,7 +176,9 @@ function Get-DirectoryActivityLogs {
     if ($output -eq "JSON") {
         $processedEvents | ConvertTo-Json -Depth 100 | Set-Content -Path "$OutputDir/$($date)-DirectoryActivityLogs.JSON"   
     }
-
+    elseif ($output -eq "JSONL") {
+        $processedEvents | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputDir/$($date)-DirectoryActivityLogs.jsonl" -Encoding $Encoding
+    }
     elseif ($output -eq "CSV") {
         $processedEvents | Export-Csv -Path "$OutputDir/$($date)-DirectoryActivityLogs.csv" -NoTypeInformation -Encoding $Encoding
     }

--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -21,7 +21,7 @@ function Get-UAL {
 	Default: Now
 
 	.PARAMETER Output
-    Output is the parameter specifying the CSV, JSON, or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
+    Output is the parameter specifying the CSV, JSON, JSONL or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
 	Default: CSV
 
 	.PARAMETER OutputDir
@@ -29,7 +29,7 @@ function Get-UAL {
 	Default: Output\UnifiedAuditLog
 
  	.PARAMETER MergeOutput
-    MergeOutput is the parameter specifying if you wish to merge CSV/JSON/SOF-ELK outputs to a single file.
+    MergeOutput is the parameter specifying if you wish to merge CSV/JSON/JSONL/SOF-ELK outputs to a single file.
 
 	.PARAMETER Encoding
     Encoding is the parameter specifying the encoding of the CSV/JSON output file.
@@ -130,7 +130,7 @@ function Get-UAL {
 			[string]$Group = $null,
 			[array]$RecordType = $null,
 			[array]$Operation = $null,
-			[ValidateSet("CSV", "JSON", "SOF-ELK")]
+			[ValidateSet("CSV", "JSON", "SOF-ELK", "JSONL")]
 			[string]$Output = "CSV",
 			[switch]$MergeOutput,
 			[string]$OutputDir,
@@ -709,6 +709,12 @@ function Get-UAL {
 											}
 											Add-Content "$OutputDir/UAL-$sessionID.json" "`n"
 										}
+										elseif ($Output -eq "JSONL") {
+											$stats.FilesCreated++
+											$allResults | ForEach-Object {
+												$_ | ConvertTo-Json -Compress -Depth 100 | Out-File -Append "$outputPath.jsonl" -Encoding $Encoding
+											}
+										}
 										elseif ($Output -eq "CSV") {
 											$stats.FilesCreated++
 											$allResults | export-CSV "$outputPath.csv" -NoTypeInformation -Append -Encoding $Encoding
@@ -772,6 +778,7 @@ function Get-UAL {
         switch ($Output) {
             "CSV" { Merge-OutputFiles -OutputDir $OutputDir -OutputType "CSV" -MergedFileName "UAL-Combined.csv" }
             "JSON" { Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSON" -MergedFileName "UAL-Combined.json" }
+			"JSONL" { Merge-OutputFiles -OutputDir $OutputDir -OutputType "JSONL" -MergedFileName "UAL-Combined.jsonl" }
             "SOF-ELK" { Merge-OutputFiles -OutputDir $OutputDir -OutputType "SOF-ELK" -MergedFileName "UAL-Combined.json" }
         }
     }

--- a/Scripts/Get-UALGraph.ps1
+++ b/Scripts/Get-UALGraph.ps1
@@ -27,7 +27,7 @@ Function Get-UALGraph {
     Default: 250000
 
     .PARAMETER Output
-    Output is the parameter specifying the CSV, JSON, or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
+    Output is the parameter specifying the CSV, JSON, JSONL or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
     Default: JSON
 
     .PARAMETER LogLevel
@@ -296,6 +296,11 @@ Function Get-UALGraph {
                 $filePath = Join-Path -Path $OutputDir -ChildPath $outputFilePath
                 $csvCollection = @()
             }
+            elseif ($Output -eq "JSONL") {
+                $outputFilePath = "$outputFileBase-part$fileCounter.jsonl"
+                $filePath = Join-Path -Path $OutputDir -ChildPath $outputFilePath
+                $firstRecordInFile = $true
+            }
             elseif ($Output -eq "SOF-ELK") {
                 $outputFilePath = "$outputFileBase-part$fileCounter.json"
                 $filePath = Join-Path -Path $OutputDir -ChildPath $outputFilePath
@@ -312,6 +317,11 @@ Function Get-UALGraph {
                 $outputFilePath = "$outputFileBase.csv"
                 $filePath = Join-Path -Path $OutputDir -ChildPath $outputFilePath
                 $csvCollection = @()
+            }
+            elseif ($Output -eq "JSONL") {
+                $outputFilePath = "$outputFileBase.jsonl"
+                $filePath = Join-Path -Path $OutputDir -ChildPath $outputFilePath
+                $firstRecordInFile = $true
             }
             elseif ($Output -eq "SOF-ELK") {
                 $outputFilePath = "$outputFileBase.json"
@@ -435,6 +445,27 @@ Function Get-UALGraph {
                         $csvCollection = @()
                         $outputFilePath = "$outputFileBase-part$fileCounter.csv"
                         $filePath = Join-Path -Path $OutputDir -ChildPath $outputFilePath
+                    }
+                }
+                elseif ($Output -eq "JSONL") {
+                    foreach ($record in $responseJson.value) {
+                        if ($SplitFiles -and $currentFileEvents -ge $MaxEventsPerFile) {
+                            Write-LogFile -Message "[INFO] File complete: $outputFilePath ($currentFileEvents events)" -Level Standard
+                            
+                            $fileCounter++
+                            $summary.ExportedFiles++
+                            $currentFileEvents = 0
+
+                            $outputFilePath = "$outputFileBase-part$fileCounter.jsonl"
+                            $filePath = Join-Path -Path $OutputDir -ChildPath $outputFilePath
+                        }
+                        if ($record.auditData) {
+                            $record.auditData | ConvertTo-Json -Compress -Depth 100 | 
+                                Out-File -Append $filePath -Encoding UTF8
+                        }
+                        "`r`n" | Out-File -FilePath $filePath -Append -Encoding UTF8
+                        $currentFileEvents++
+                        $summary.ProcessedRecords++
                     }
                 }
                 elseif ($Output -eq "SOF-ELK") {

--- a/docs/source/functionality/Azure/AzureDirectoryActivityLogs.rst
+++ b/docs/source/functionality/Azure/AzureDirectoryActivityLogs.rst
@@ -35,7 +35,7 @@ Parameters
     - Default: Now
 
 -Output (optional)
-    - Output is the parameter specifying the CSV or JSON output type.
+    - Output is the parameter specifying the CSV, JSONL or JSON output type.
     - Default: CSV
 
 -OutputDir (optional)

--- a/docs/source/functionality/M365/AdminAuditLog.rst
+++ b/docs/source/functionality/M365/AdminAuditLog.rst
@@ -36,7 +36,7 @@ Parameters
     - Default: Output\AdminAuditLog
 
 -Output (optional)
-    - Output is the parameter specifying the CSV, JSON or SOF-ELK output type.
+    - Output is the parameter specifying the CSV, JSON, JSONL or SOF-ELK output type.
     - The SOF-ELK output type can be used to export logs in a format suitable for the [platform of the same name](https://github.com/philhagen/sof-elk).
     - Default: CSV
 

--- a/docs/source/functionality/M365/UnifiedAuditLog.rst
+++ b/docs/source/functionality/M365/UnifiedAuditLog.rst
@@ -125,7 +125,7 @@ Parameters
     - Interval is the parameter specifying the interval in which the logs are being gathered.
 
 -Output (optional)
-    - Output is the parameter specifying the CSV or JSON output type.
+    - Output is the parameter specifying the CSV, JSONL, SOF-ELK or JSON output type.
     - Default: CSV
 
 -MergeOutput (optional)

--- a/docs/source/functionality/M365/UnifiedAuditLogGraph.rst
+++ b/docs/source/functionality/M365/UnifiedAuditLogGraph.rst
@@ -90,7 +90,7 @@ Parameters
     - Default: Standard
 
 -Output (optional)
-    - Output is the parameter specifying the CSV or JSON output type.
+    - Output is the parameter specifying the CSV, JSONL or JSON output type.
     - Default: JSON
 
 -MaxEventsPerFile (optional)


### PR DESCRIPTION
This PR adds support for the jsonl (JSON Lines) format across all supported Microsoft 365 log types (e.g., UAL, Sign-In, Entra Audit).

**Changes:**

- New -Output jsonl option for line-delimited JSON export.
- Enables better compatibility with tools like Plaso, Timesketch, jq, and SIEM pipelines.
- Existing formats (csv, json, sofelk) remain unchanged.

**Benefit:**
Efficient parsing and large-scale log processing for forensic and security workflows.