### PR TITLE
Fix UAL interval calculation for small collections

### DIFF
--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -409,14 +409,13 @@ function Get-UAL {
 			if ($null -ne $totalResults -And $totalResults -gt 1) {
 				$estimatedIntervals = [math]::Ceiling($totalResults / $MaxItemsPerInterval)
 				
-				if ($estimatedIntervals -eq 0) {
+				if ($estimatedIntervals -lt 2) {
 					$Interval = $totalMinutes
 				} else {
 					$Interval = [math]::Max(1, [math]::Floor(($totalMinutes / $estimatedIntervals) / 1.2))
-					
-					Write-LogFile -Message "[INFO] Using interval of $Interval minutes based on estimated $totalResults records" -Level Standard -Color "Green"
 				}
-			} 
+				Write-LogFile -Message "[INFO] Using interval of $Interval minutes based on estimated $totalResults records" -Level Standard -Color "Green"
+			}
 			else { 
 				$Interval = 60
 			}


### PR DESCRIPTION
If we currently have a collection that we can do within 1 interval, for example if we only need to collect 500 events, the calculation still makes it two intervals. This is due to the `/ 1.2` factor. This PR changes the calculation to take the complete `totalMinutes` as long as there is only 1 interval needed. 