### PR TITLE
Fix timezones in commandlets

### DIFF
--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -68,7 +68,7 @@ function EndDate {
         }
     }
     else {
-        $script:endDate = [datetime]::Parse($startDate).ToUniversalTime()
+        $script:endDate = [datetime]::Parse($endDate).ToUniversalTime()
         if (!$endDate -and -not $Quiet) { 
             Write-LogFile -Message "[WARNING] Not A valid end date and time, make sure to use YYYY-MM-DD" -Color "Red"
         } 

--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -29,16 +29,17 @@ if (!(test-path $outputDir)) {
 $retryCount = 0 
 	
 Function StartDate {
-    param([switch]$Quiet)
-    
+    param([switch]$Quiet,
+          [int]$DefaultOffset = -90)
+
     if (($startDate -eq "") -Or ($null -eq $startDate)) {
-        $script:StartDate = [datetime]::Now.ToUniversalTime().AddDays(-90)
+        $script:StartDate = [datetime]::Now.ToUniversalTime().AddDays($DefaultOffset)
         if (-not $Quiet) {
             Write-LogFile -Message "[INFO] No start date provided by user setting the start date to: $($script:StartDate.ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Yellow"
         }
     }
     else {
-        $script:startDate = $startDate -as [datetime]
+        $script:startDate = [datetime]::Parse($startDate).ToUniversalTime()
         if (!$script:startDate -and -not $Quiet) { 
             Write-LogFile -Message "[WARNING] Not A valid start date and time, make sure to use YYYY-MM-DD" -Color "Red"
         } 
@@ -47,36 +48,14 @@ Function StartDate {
 
 Function StartDateUAL {
     param([switch]$Quiet)
-    
-    if (($startDate -eq "") -Or ($null -eq $startDate)) {
-        $script:StartDate = [datetime]::Now.ToUniversalTime().AddDays(-180)
-        if (-not $Quiet) {
-            Write-LogFile -Message "[INFO] No start date provided by user setting the start date to: $($script:StartDate.ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Yellow"
-        }
-    }
-    else {
-        $script:startDate = $startDate -as [datetime]
-        if (!$script:startDate -and -not $Quiet) { 
-            Write-LogFile -Message "[WARNING] Not A valid start date and time, make sure to use YYYY-MM-DD" -Color "Red"
-        } 
-    }
+
+    StartDate -Quiet:$Quiet -DefaultOffset:-180
 }
 
 Function StartDateAz {
     param([switch]$Quiet)
     
-    if (($startDate -eq "") -Or ($null -eq $startDate)) {
-        $script:StartDate = [datetime]::Now.ToUniversalTime().AddDays(-30)
-        if (-not $Quiet) {
-            Write-LogFile -Message "[INFO] No start date provided by user setting the start date to: $($script:StartDate.ToString("yyyy-MM-ddTHH:mm:ssK"))" -Color "Yellow"
-        }
-    }
-    else {
-        $script:startDate = $startDate -as [datetime]
-        if (!$script:startDate -and -not $Quiet) { 
-            Write-LogFile -Message "[WARNING] Not A valid start date and time, make sure to use YYYY-MM-DD" -Color "Red"
-        } 
-    }
+    StartDate -Quiet:$Quiet -DefaultOffset:-30
 }
 
 function EndDate {
@@ -89,7 +68,7 @@ function EndDate {
         }
     }
     else {
-        $script:endDate = $endDate -as [datetime]
+        $script:endDate = [datetime]::Parse($startDate).ToUniversalTime()
         if (!$endDate -and -not $Quiet) { 
             Write-LogFile -Message "[WARNING] Not A valid end date and time, make sure to use YYYY-MM-DD" -Color "Red"
         } 

--- a/Scripts/Get-AdminAuditLog.ps1
+++ b/Scripts/Get-AdminAuditLog.ps1
@@ -46,8 +46,8 @@ function Get-AdminAuditLog {
     Displays the total number of logs within the admin audit log.
 
     .EXAMPLE
-    Get-AdminAuditLog -StartDate 1/4/2024 -EndDate 5/4/2024
-    Collects the admin audit log between 1/4/2024 and 5/4/2024
+    Get-AdminAuditLog -StartDate 2025-04-01 -EndDate 2025-04-05
+    Collects the admin audit log between 2025-04-01 and 2025-04-05
 #>
     [CmdletBinding()]
     param(

--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -84,8 +84,8 @@ function Get-UAL {
 	Gets all the unified audit log entries for the users Test@invictus-ir.com and HR@invictus-ir.com.
 	
 	.EXAMPLE
-	Get-UAL -UserIds Test@invictus-ir.com -StartDate 1/4/2024 -EndDate 5/4/2024
-	Gets all the unified audit log entries between 1/4/2024 and 5/4/2024 for the user Test@invictus-ir.com.
+	Get-UAL -UserIds Test@invictus-ir.com -StartDate 2025-04-01 -EndDate 2025-04-05
+	Gets all the unified audit log entries between 2025-04-01 and 2025-04-05 for the user Test@invictus-ir.com.
 	
 	.EXAMPLE
 	Get-UAL -UserIds -Interval 720

--- a/docs/source/functionality/M365/AdminAuditLog.rst
+++ b/docs/source/functionality/M365/AdminAuditLog.rst
@@ -16,10 +16,10 @@ Running the script without any parameters will gather the Admin Audit log for th
 
    Get-AdminAuditLog
 
-Get the admin audit log between 1/4/2025 and 5/4/2025:
+Get the admin audit log between 2025-04-01 and 2025-04-05:
 ::
 
-   Get-AdminAuditLog -StartDate 1/4/2025 -EndDate 5/4/2025
+   Get-AdminAuditLog -StartDate 2025-04-01 -EndDate 2025-04-05
 
 Parameters
 """"""""""""""""""""""""""

--- a/docs/source/functionality/M365/UnifiedAuditLog.rst
+++ b/docs/source/functionality/M365/UnifiedAuditLog.rst
@@ -28,10 +28,10 @@ Displays the total number of logs within the unified audit log:
 
    Get-UALStatistics
 
-Displays the total number of logs within the unified audit log between 1/4/2025 and 5/4/2025 for the user test[@]invictus-ir.com:
+Displays the total number of logs within the unified audit log between 2025-04-01 and 2025-04-05 for the user test[@]invictus-ir.com:
 ::
 
-   Get-UALStatistics -UserIds test[@]invictus-ir.com -StartDate 1/4/2025 -EndDate 5/4/2025
+   Get-UALStatistics -UserIds test[@]invictus-ir.com -StartDate 2025-04-01 -EndDate 2025-04-05
 
 Parameters
 """"""""""""""""""""""""""


### PR DESCRIPTION
This PR fixes the input timezones for the different commandlets. Now all the timezones are UTC if you input them as UTC. 

Fixes #155 