### PR TITLE
Add Get-EntraApplications commandlet

### DIFF
--- a/Microsoft-Extractor-Suite.psd1
+++ b/Microsoft-Extractor-Suite.psd1
@@ -36,6 +36,7 @@
 		".\Scripts\Get-RiskyEvents.ps1"
 		".\Scripts\Get-ConditionalAccessPolicy.ps1"
 		".\Scripts\Get-Emails.ps1"
+		".\Scripts\Get-EntraApplications.ps1"
 		".\Scripts\Get-MailItemsAccessed.ps1"
 		".\Scripts\Get-UALGraph.ps1"
 		".\Scripts\Get-AzureDirectoryActivityLogs.ps1"
@@ -119,6 +120,9 @@
 		"Get-Email"
 		"Get-Attachment"
 		"Show-Email"
+
+		# Get-EntraApplications.ps1
+		"Get-EntraApplications"
 	
 		# Get-MailItemsAccessed.ps1
 		"Get-Sessions"

--- a/Microsoft-Extractor-Suite.psm1
+++ b/Microsoft-Extractor-Suite.psm1
@@ -244,6 +244,119 @@ function Get-GraphAuthType {
     }
 }
 
+function Init-Logging {
+    Set-LogLevel -Level ([LogLevel]::$LogLevel)
+	$isDebugEnabled = $script:LogLevel -eq [LogLevel]::Debug
+
+	$script:scriptStartedAt = Get-Date
+
+	if ($isDebugEnabled) {
+        Write-LogFile -Message "[DEBUG] PowerShell Version: $($PSVersionTable.PSVersion)" -Level Debug
+        Write-LogFile -Message "[DEBUG] Input parameters:" -Level Debug
+        foreach ($param in $PSBoundParameters.GetEnumerator()) {
+            Write-LogFile -Message "[DEBUG]   $($param.Key): $($param.Value)" -Level Debug
+        }
+
+        $graphModule = Get-Module -Name Microsoft.Graph* -ErrorAction SilentlyContinue
+        if ($graphModule) {
+            Write-LogFile -Message "[DEBUG] Microsoft Graph Modules loaded:" -Level Debug
+            foreach ($module in $graphModule) {
+                Write-LogFile -Message "[DEBUG]   - $($module.Name) v$($module.Version)" -Level Debug
+            }
+        } else {
+            Write-LogFile -Message "[DEBUG] No Microsoft Graph modules loaded" -Level Debug
+        }
+    }
+}
+
+function Check-GraphContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]$RequiredScopes
+    )
+
+    $graphAuth = Get-GraphAuthType -RequiredScopes $RequiredScopes
+
+    if ($isDebugEnabled) {
+        Write-LogFile -Message "[DEBUG] Graph authentication completed" -Level Debug
+        try {
+            $context = Get-MgContext
+            if ($context) {
+                Write-LogFile -Message "[DEBUG] Graph context information:" -Level Debug
+                Write-LogFile -Message "[DEBUG]   Account: $($context.Account)" -Level Debug
+                Write-LogFile -Message "[DEBUG]   Environment: $($context.Environment)" -Level Debug
+                Write-LogFile -Message "[DEBUG]   TenantId: $($context.TenantId)" -Level Debug
+                Write-LogFile -Message "[DEBUG]   Scopes: $($context.Scopes -join ', ')" -Level Debug
+            }
+        } catch {
+            Write-LogFile -Message "[DEBUG] Could not retrieve Graph context details" -Level Debug
+        }
+    }
+}
+
+function Init-OutputDir {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Component,
+        [string]$SubComponent = "",
+        [Parameter(Mandatory=$true)]
+        [string]$FilePostfix
+    )
+
+	$date = [datetime]::Now.ToString('yyyyMMdd')
+	if ($OutputDir -eq "" ){
+		$OutputDir = "Output\$Component\$($date)"
+		if ($SubComponent -ne "") {
+            $OutputDir += "-$SubComponent"
+        }
+		if (!(test-path $OutputDir)) {
+		    Write-LogFile -Message "[DEBUG] Creating output directory: $OutputDir" -Level Debug
+			New-Item -ItemType Directory -Force -path $OutputDir > $null
+		}
+	}
+	else {
+        if (!(Test-Path -Path $OutputDir)) {
+            Write-LogFile -Message "[Error] Custom directory invalid: $OutputDir" -Level Minimal -Color "Red"
+            return
+        }
+    }
+
+    Write-LogFile -Message "[DEBUG] Using output directory: $OutputDir" -Level Debug
+    $filename = "$($date)-$FilePostfix.csv"
+	$script:outputFile = Join-Path $OutputDir $filename
+}
+
+function Write-Summary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]$Summary
+    )
+
+    Write-LogFile -Message "`n=== Summary ===" -Color "Cyan" -Level Standard
+    foreach ($param in $Summary.GetEnumerator()) {
+        if ($param.value -is [hashtable] -or $param.value -is [System.Collections.Specialized.OrderedDictionary]) {
+            Write-LogFile -Message "$($param.key):" -Level Standard
+            foreach($subitem in $param.value.GetEnumerator()) {
+                Write-LogFile -Message "  $($subitem.key): $($subitem.value)" -Level Standard
+            }
+            Write-LogFile -Message " " -Level Standard
+        } else {
+            Write-LogFile -Message "$($param.key): $($param.value)" -Level Standard
+        }
+    }
+
+    $ProcessingTime = (Get-Date) - $script:ScriptStartedAt
+    Write-LogFile -Message "`nExport Details:" -Level Standard
+    Write-LogFile -Message "  Output File: $script:outputFile" -Level Standard
+    Write-LogFile -Message "  Processing Time: $($ProcessingTime.ToString('mm\:ss'))" -Color "Green" -Level Standard
+    Write-LogFile -Message "===================================" -Color "Cyan" -Level Standard
+
+
+}
+
 function Merge-OutputFiles {
     param (
         [Parameter(Mandatory)][string]$OutputDir,

--- a/Scripts/Get-EntraApplications.ps1
+++ b/Scripts/Get-EntraApplications.ps1
@@ -1,0 +1,68 @@
+function Get-EntraApplications {
+    <#
+    .SYNOPSIS
+    Gets of current Azure Entra ID applications.
+
+    .DESCRIPTION
+    TheGet-EntraApplications GraphAPI cmdlet collects the current state of .
+
+	.PARAMETER LogLevel
+    Specifies the level of logging:
+    None: No logging
+    Minimal: Critical errors only
+    Standard: Normal operational logging
+	Debug: Verbose logging for debugging purposes
+    Default: Standard
+
+    .PARAMETER OutputDir
+    outputDir is the parameter specifying the output directory.
+    Default: The output will be written to: Output\EntraID\{date_Applications}\{timestamp}-Applications.json
+
+    .PARAMETER Encoding
+    Encoding is the parameter specifying the encoding of the JSON output file.
+    Default: UTF8
+
+    .EXAMPLE
+    Get-EntraApplications
+    Get all Entra applications
+#>
+    [CmdletBinding()]
+    param(
+        [string]$OutputDir,
+        [string]$Encoding = "UTF8",
+        [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
+        [string]$LogLevel = 'Standard'
+	)
+
+    Init-Logging
+    Write-LogFile -Message "=== Starting Application Collection ===" -Color "Cyan" -Level Standard
+    Init-OutputDir -Component "EntraID" -SubComponent "Applications" -FilePostfix "Applications"
+	$requiredScopes = @("Application.Read.All")
+    Check-GraphContext -RequiredScopes $requiredScopes
+
+    Write-LogFile -Message "[INFO] Collecting EntraID Applications"
+    $applications = Get-MgApplication
+    $results = @()
+    foreach ($app in $applications) {
+        $owners = Get-MgApplicationOwner -ApplicationId $app.Id
+        $object = [PSCustomObject]@{
+            DisplayName = $app.DisplayName
+            Id = $app.Id
+            AppId  = $app.AppId
+            CreatedDateTime = $app.CreatedDateTime
+            OwnerIds =  $owners | ForEach-Object { $_.Id  }  | join-String -Separator ", "
+            OwnerDisplayNames = ""
+        }
+
+        if ($owners.AdditionalProperties) {
+            $object.OwnerDisplayNames = $owners.AdditionalProperties | ForEach-Object { $_['displayName'] }  | join-String -Separator ", "
+        }
+        $results += $object
+    }
+    $results | Export-Csv -Path $script:outputFile -NoTypeInformation -Encoding $Encoding
+
+    $summary = @{
+		TotalApplications = $results.Count
+	}
+	Write-Summary -Summary $summary
+}


### PR DESCRIPTION
This PR adds a commandlet to get the current Applications registred within Entra ID. 

When developing this I observed that many commands have the same kind of flow, with quite a lot of duplication. First setup logging, create the output dir, check the graph scopes, than actually do what it should do, and then finish with a summary. I added a few functions which take all this kind of setup/teardown logic such that it gets both consistent and makes the actual collection code easier to find. I have applied it only to `Get-Devices` for now, to keep this MR reasonable. I would suggest we apply this structure to all the commandlets, such that we get the initialization process more consistent.