### PR TITLE
Fix UAL interval when only 1 event in record

### DIFF
--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -405,21 +405,15 @@ function Get-UAL {
 
 		if (!$PSBoundParameters.ContainsKey('Interval')) {
 			$totalMinutes = ($script:EndDate - $script:StartDate).TotalMinutes
-		
-			if ($null -ne $totalResults -And $totalResults -gt 0) {
-				$estimatedIntervals = [math]::Ceiling($totalResults / $MaxItemsPerInterval)
-				
-				if ($estimatedIntervals -lt 2) {
-					$Interval = $totalMinutes
-				} else {
-					$Interval = [math]::Max(1, [math]::Floor(($totalMinutes / $estimatedIntervals) / 1.2))					
-				}
-				
-				Write-LogFile -Message "[INFO] Using interval of $Interval minutes based on estimated $totalResults records" -Level Standard -Color "Green"
-			} 
-			else { 
-				$Interval = $totalMinutes
-			}
+            $estimatedIntervals = [math]::Ceiling($totalResults / $MaxItemsPerInterval)
+
+            if ($estimatedIntervals -lt 2) {
+                $Interval = $totalMinutes
+            } else {
+                $Interval = [math]::Max(1, [math]::Floor(($totalMinutes / $estimatedIntervals) / 1.2))
+            }
+
+            Write-LogFile -Message "[INFO] Using interval of $Interval minutes based on estimated $totalResults records" -Level Standard -Color "Green"
 		}
 
 		$resetInterval = $Interval

--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -406,7 +406,7 @@ function Get-UAL {
 		if (!$PSBoundParameters.ContainsKey('Interval')) {
 			$totalMinutes = ($script:EndDate - $script:StartDate).TotalMinutes
 		
-			if ($null -ne $totalResults -And $totalResults -gt 1) {
+			if ($null -ne $totalResults -And $totalResults -gt 0) {
 				$estimatedIntervals = [math]::Ceiling($totalResults / $MaxItemsPerInterval)
 				
 				if ($estimatedIntervals -lt 2) {
@@ -418,7 +418,7 @@ function Get-UAL {
 				Write-LogFile -Message "[INFO] Using interval of $Interval minutes based on estimated $totalResults records" -Level Standard -Color "Green"
 			} 
 			else { 
-				$Interval = 60
+				$Interval = $totalMinutes
 			}
 		}
 


### PR DESCRIPTION
Fixes #160 

When there was 1 or less results in the collection window the interval was set to 60 minutes. However, we can just use the interval calculation since that would result in the estimatedIntervals to be 1 resulting in 1 collection round. Next to that we don't need the check anymore, since if there are 0 results in the collection window we won't hit this code since there is already a check at line 396.