### PR TITLE
Prevent endless loop with empty dataset in UAL

### DIFF
--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -623,6 +623,10 @@ function Get-UAL {
 													if ($isDebugEnabled) {
                                                         Write-LogFile -Message "[DEBUG]   WARNING: Empty dataset returned" -Level Debug
                                                     }
+													if($performance.TotalSeconds -ge 960) {
+														Write-LogFile -Message "[WARNING] API call took $([math]::round($performance.TotalSeconds, 2)) seconds, indicating an issue with the Microsoft API. Restarting batch." -Color "Yellow" -Level Standard
+														break
+													}
 													if($emptyRetryCount -ge 3) {
 														Write-LogFile -Message "[WARNING] Received multiple empty datasets, restarting batch." -Color "Yellow" -Level Standard
 														break

--- a/Scripts/Get-UAL.ps1
+++ b/Scripts/Get-UAL.ps1
@@ -586,6 +586,7 @@ function Get-UAL {
                                                 Write-LogFile -Message "[DEBUG]   Using result size: $resultSize" -Level Debug
                                             }
 
+											$emptyRetryCount = 0;
 											while ($totalProcessed -lt $amountResults) {
                                                 
                                                 if ($isDebugEnabled) {
@@ -622,7 +623,12 @@ function Get-UAL {
 													if ($isDebugEnabled) {
                                                         Write-LogFile -Message "[DEBUG]   WARNING: Empty dataset returned" -Level Debug
                                                     }
+													if($emptyRetryCount -ge 3) {
+														Write-LogFile -Message "[WARNING] Received multiple empty datasets, restarting batch." -Color "Yellow" -Level Standard
+														break
+													}
 												}
+												$emptyRetryCount++;
 											}
 
 											if ($totalProcessed -ne $amountResults) {


### PR DESCRIPTION
When the `Search-UnifiedAuditLog` kept returning an emtpy dataset this would result in an endless loop (since this is wrapped in a while loop). This PR adds a check that we only retry it 4 times. If that fails it will continue and the batch retry logic will try it another 4 times but with another `sessionId` which might fix the requests towards the API. This at least prevents us from endless trying to get data but not getting anything.

Example log without this MR indicating the issue:
```
[INFO] Total number of events during the acquisition period: 1886
[INFO] Using interval of 7200 minutes based on estimated 1886 records
[INFO] Found 1886 audit logs between 2025-09-18T00:00:00Z and 2025-09-23T00:00:00Z
[DEBUG]   Starting batch retrieval with session ID: fd101f98-301d-4c0a-9fa1-fe464eff669d
[DEBUG]   Using result size: 5000
[DEBUG]   Fetching Unified Audit Log
[DEBUG]   Fetching results batch (0/1886 processed so far)
Write-Error: A server side error has occurred because of which the operation could not be
completed. Please try again after some time. If the problem still persists,
please reach out to MS support.
[DEBUG]   Fetch UAL took 960.11 seconds
[DEBUG]   WARNING: Empty dataset returned
[DEBUG]   Fetching Unified Audit Log
[DEBUG]   Fetching results batch (0/1886 processed so far)
Write-Error: A server side error has occurred because of which the operation could not be
completed. Please try again after some time. If the problem still persists,
please reach out to MS support.
[DEBUG]   Fetch UAL took 960.11 seconds
[DEBUG]   WARNING: Empty dataset returned
[DEBUG]   Fetching Unified Audit Log
[DEBUG]   Fetching results batch (0/1886 processed so far)
Write-Error: A server side error has occurred because of which the operation could not be
completed. Please try again after some time. If the problem still persists,
please reach out to MS support.
[DEBUG]   Fetch UAL took 960.11 seconds
[DEBUG]   WARNING: Empty dataset returned
```