### PR TITLE
fix: typo in Get-Devices command on Start-EvidenceCollection breaking its execution due to PR#175

### DIFF
--- a/Scripts/Get-AllEvidence.ps1
+++ b/Scripts/Get-AllEvidence.ps1
@@ -103,15 +103,15 @@ $Global:CollectionTasks = @{
             Function = { param($OutputDir, $LogLevel, $UserIds, $Output)
                 if ($UserIds) {
                     if ($OutputDir) {
-                        Get-Devices -OutputDir $OutputDir -LogLevel $LogLevel -UserIds $UserIds, $Output
+                        Get-Devices -OutputDir $OutputDir -LogLevel $LogLevel -UserIds $UserIds -Output $Output
                     } else {
-                        Get-Devices -LogLevel $LogLevel -UserIds $UserIds, $Output
+                        Get-Devices -LogLevel $LogLevel -UserIds $UserIds -Output $Output
                     }                    
                 } else {
                     if ($OutputDir) {
-                        Get-Devices -OutputDir $OutputDir -LogLevel $LogLevel, $Output
+                        Get-Devices -OutputDir $OutputDir -LogLevel $LogLevel -Output $Output
                     } else {
-                        Get-Devices -LogLevel $LogLevel, $Output
+                        Get-Devices -LogLevel $LogLevel -Output $Output
                     }
                 }
                 return $true


### PR DESCRIPTION
Testing error made during the development of the following merge request `Merge pull request https://github.com/invictus-ir/Microsoft-Extractor-Suite/pull/175 from k8pl3r-sh/fix-Start-EvidenceCollection`.

On line 106, 108, 112, 114, replace `, $Output` by ` -Output $Output` to fix the error `[FAILED] Devices - Cannot process argument transformation on parameter 'LogLevel'. Cannot convert value to type System.String.` which was made by mistake on my previous PR. The error prevented from collecting Devices properly.