### PR TITLE
Add resumable export, state file, and batchsize support to Get-UALGraph

### DIFF
--- a/Scripts/Get-UALGraph.ps1
+++ b/Scripts/Get-UALGraph.ps1
@@ -1,109 +1,27 @@
-Function Get-UALGraph {
-<#
-    .SYNOPSIS
-    Gets all the unified audit log entries.
-
-    .DESCRIPTION
-    Makes it possible to extract all unified audit data out of a Microsoft 365 environment. 
-    The output will be written to: Output\UnifiedAuditLog\
-
-    .PARAMETER UserIds
-    UserIds is the UserIds parameter filtering the log entries by the account of the user who performed the actions.
-
-    .PARAMETER StartDate
-    startDate is the parameter specifying the start date of the date range.
-    Default: Today -90 days
-
-    .PARAMETER EndDate
-    endDate is the parameter specifying the end date of the date range.
-    Default: Now
-
-    .PARAMETER OutputDir
-    OutputDir is the parameter specifying the output directory.
-    Default: Output\UnifiedAuditLog
-
-    .PARAMETER MaxEventsPerFile
-    Specifies the maximum number of events per output file. When this number is reached, a new file will be created.
-    Default: 250000
-
-    .PARAMETER Output
-    Output is the parameter specifying the CSV, JSON, JSONL or SOF-ELK output type. The SOF-ELK output can be imported into the platform of the same name.
-    Default: JSON
-
-    .PARAMETER Output
-    Output is the parameter specifying the CSV, JSON, JSONL, or SOF-ELK output type. 
-    Note: JSONL format is only supported by specific functions (Get-AdminAuditLog, Get-AllEvidence, Get-AzureDirectoryActivityLogs, Get-UAL, Get-UALGraph).
-    Other tasks automatically use JSON format regardless of this setting.
-    Default: JSON
-
-    .PARAMETER LogLevel
-    Specifies the level of logging:
-    None: No logging
-    Minimal: Critical errors only
-    Standard: Normal operational logging
-    Debug: Verbose logging for debugging purposes
-    Default: Standard
-
-    .PARAMETER Encoding
-    Encoding is the parameter specifying the encoding of the CSV/JSON output file.
-    Default: UTF8
-
-    .PARAMETER RecordType
-    The RecordType parameter filters the log entries by record type.
-    Options are: ExchangeItem, ExchangeAdmin, etc.
-
-    .PARAMETER Keyword
-    The Keyword parameter allows you to filter the Unified Audit Log for specific keywords.
-
-    .PARAMETER Service
-    The Service parameter filters the Unified Audit Log based on the specific services.
-    Options are: Exchange,Skype,Sharepoint etc.
-
-    .PARAMETER Operations
-    The Operations parameter filters the log entries by operation or activity type. Usage: -Operations UserLoggedIn,MailItemsAccessed
-    Options are: New-MailboxRule, MailItemsAccessed, etc.
-
-    .PARAMETER IPAddress
-    The IP address parameter is used to filter the logs by specifying the desired IP address.
-    
-    .PARAMETER SearchName
-    Specifies the name of the search query. This parameter is required.
-
-    .PARAMETER SplitFiles
-    When specified, splits output into multiple files based on MaxEventsPerFile.
-    When set to True, splits output into multiple files based on MaxEventsPerFile.
-    Default: If not specified, outputs to a single file.
-
-    .PARAMETER ObjectIDs 
-    Exact data returned depends on the service in the current `@odatatype.microsoft.graph.security.auditLogQuery` record.
-    For Exchange admin audit logging, the name of the object modified by the cmdlet.
-    For SharePoint activity, the full URL path name of the file or folder accessed by a user. 
-    For Microsoft Entra activity, the name of the user account that was modified.|
-    
-    .EXAMPLE
-    Get-UALGraph -searchName Test 
-    Gets all the unified audit log entries.
-    
-    .EXAMPLE
-    Get-UALGraph -searchName Test -UserIds Test@invictus-ir.com
-    Gets all the unified audit log entries for the user Test@invictus-ir.com.
-    
-    .EXAMPLE
-    Get-UALGraph -searchName Test -startDate "2025-03-10T09:28:56Z" -endDate "2025-03-20T09:28:56Z" -Service Exchange
-    Retrieves audit log data for the specified time range March 10, 2025 to March 20, 2025 and filters the results to include only events related to the Exchange service.
-    
-    .EXAMPLE
-    Get-UALGraph -searchName Test -startDate "2025-03-01" -endDate "2025-03-10" -IPAddress 182.74.242.26
-    Retrieve audit log data for the specified time range March 1, 2025 to March 10, 2025 and filter the results to include only entries associated with the IP address 182.74.242.26.
-
-    .EXAMPLE
-    Get-UALGraph -searchName Test -MaxEventsPerFile 500000 -SplitFiles
-    Gets all the unified audit log entries with 500,000 events per output file.
-
-#>
+function Format-AuditRecordForCsv {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]$searchName,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Record
+    )
+    process {
+        $Record | Select-Object id, createdDateTime, auditLogRecordType, operation, organizationId, userType, userId, service, objectId, userPrincipalName, clientIp, administrativeUnits, @{Name = "auditData"; Expression = { $_.auditData | ConvertTo-Json -Depth 100 -Compress } }
+    }
+}
+
+function Save-StateFile {
+    param(
+        [Parameter(Mandatory = $true)]$State,
+        [Parameter(Mandatory = $true)]$StateFilePath
+    )
+    $State.lastUpdated = (Get-Date).ToString('o')
+    $State | ConvertTo-Json -Depth 10 | Set-Content -Path $StateFilePath -Encoding UTF8
+}
+
+Function Get-UALGraph {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]$searchName,
         [string]$OutputDir,
         [string]$Encoding = "UTF8",
         [string]$startDate,
@@ -115,24 +33,28 @@ Function Get-UALGraph {
         [string[]]$UserIds = @(),
         [string[]]$IPAddress = @(),
         [string[]]$ObjectIDs = @(),
+        [ValidateRange(1, 5000)]
+        [System.Nullable[int]]$BatchSize = $null,
         [ValidateSet('None', 'Minimal', 'Standard', 'Debug')]
         [string]$LogLevel = 'Standard',
         [double]$MaxEventsPerFile = 250000,
         [ValidateSet("CSV", "JSON", "JSONL", "SOF-ELK")]
         [string]$Output = "JSON",
-        [switch]$SplitFiles
+        [switch]$SplitFiles,
+        [switch]$Resume,
+        [string]$StateFile
     )
 
     Init-OutputDir -Component "UnifiedAuditLog" -FilePostfix $searchName -CustomOutputDir $OutputDir
     Init-Logging
 
     $summary = @{
-        TotalRecords = 0
+        TotalRecords     = 0
         ProcessedRecords = 0
-        ExportedFiles = 0
-        StartTime = Get-Date
-        ProcessingTime = $null
-        SearchId = ""
+        ExportedFiles    = 0
+        StartTime        = Get-Date
+        ProcessingTime   = $null
+        SearchId         = ""
     }
 
     $requiredScopes = @("AuditLogsQuery.Read.All")
@@ -140,7 +62,7 @@ Function Get-UALGraph {
     $outputDirPath = Split-Path $script:outputFile -Parent
 
     Write-LogFile -Message "=== Starting Microsoft Graph Audit Log Retrieval ===" -Color "Cyan" -Level Standard
-    
+
     StartDate -Quiet
     EndDate -Quiet
 
@@ -150,48 +72,119 @@ Function Get-UALGraph {
     Write-LogFile -Message "Output format: $Output" -Level Standard
     Write-LogFile -Message "----------------------------------------`n" -Level Standard
 
-    $body = @{
-        "@odata.type" = "#microsoft.graph.security.auditLogQuery"
-        displayName = $searchName
-        filterStartDateTime = $script:startDate
-        filterEndDateTime = $script:endDate
-        recordTypeFilters = $RecordType
-        keywordFilter = $Keyword
-        serviceFilter = $Service
-        operationFilters = $Operations
-        userPrincipalNameFilters = $UserIds
-        ipAddressFilters = $IPAddress
-        objectIdFilters = $ObjectIDs
-        administrativeUnitIdFilters = @()
-        status = ""
-    } | ConvertTo-Json
+    $searchSucceeded = $false
 
-    try {
-        
-        if ($isDebugEnabled) {
-            Write-LogFile -Message "[DEBUG] Initiating Graph API audit log query..." -Level Debug
-            $createPerformance = Measure-Command {
-                $response = Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/security/auditLog/queries" -Body $body -ContentType "application/json"
-            }
-            Write-LogFile -Message "[DEBUG] Query creation took $([math]::round($createPerformance.TotalSeconds, 2)) seconds" -Level Debug
-        } else {
-            $response = Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/security/auditLog/queries" -Body $body -ContentType "application/json"
+    if ($Resume) {
+        if (-not $StateFile) {
+            $StateFile = Join-Path -Path (Get-Location) -ChildPath "$searchName-UALGraph-state.json"
         }
-        
-        $scanId = $response.id
+
+        if (-not (Test-Path $StateFile)) {
+            Write-LogFile -Message "[ERROR] State file not found: $StateFile" -Color "Red" -Level Minimal
+            throw "Cannot resume: state file not found. Specify path with -StateFile or ensure $searchName-UALGraph-state.json exists in current directory."
+        }
+
+        $state = Get-Content -Path $StateFile | ConvertFrom-Json
+
+        Write-LogFile -Message "[INFO] Resuming from state file: $StateFile" -Color "Cyan" -Level Standard
+        Write-LogFile -Message "[INFO] Resuming search: $($state.searchName) (ID: $($state.scanId))" -Level Standard
+        Write-LogFile -Message "[INFO] Previously processed: $($state.totalEventsProcessed) events" -Level Standard
+
+        $scanId = $state.scanId
         $summary.SearchId = $scanId
-        write-logFile -Message "[INFO] A new Unified Audit Log search has started with the name: $searchName and ID: $scanId." -Color "Green" -Level Minimal
-    
-        if ($isDebugEnabled) {
-            Write-LogFile -Message "[DEBUG] Search created successfully:" -Level Debug
-            Write-LogFile -Message "[DEBUG]   Search ID: $scanId" -Level Debug
-            Write-LogFile -Message "[DEBUG]   Response status: $($response.status)" -Level Debug
+        if ($state.searchStatus -eq "succeeded") {
+            $searchSucceeded = $true
         }
 
-        Start-Sleep -Seconds 10
         $apiUrl = "https://graph.microsoft.com/beta/security/auditLog/queries/$scanId"
 
-        write-logFile -Message "[INFO] Waiting for the scan to start..." -Level Standard
+    }
+    else {
+        $body = @{
+            "@odata.type"               = "#microsoft.graph.security.auditLogQuery"
+            displayName                 = $searchName
+            filterStartDateTime         = $script:startDate
+            filterEndDateTime           = $script:endDate
+            recordTypeFilters           = $RecordType
+            keywordFilter               = $Keyword
+            serviceFilter               = $Service
+            operationFilters            = $Operations
+            userPrincipalNameFilters    = $UserIds
+            ipAddressFilters            = $IPAddress
+            objectIdFilters             = $ObjectIDs
+            administrativeUnitIdFilters = @()
+            status                      = ""
+        } | ConvertTo-Json
+
+        try {
+
+            if ($isDebugEnabled) {
+                Write-LogFile -Message "[DEBUG] Initiating Graph API audit log query..." -Level Debug
+                $createPerformance = Measure-Command {
+                    $response = Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/security/auditLog/queries" -Body $body -ContentType "application/json"
+                }
+                Write-LogFile -Message "[DEBUG] Query creation took $([math]::round($createPerformance.TotalSeconds, 2)) seconds" -Level Debug
+            }
+            else {
+                $response = Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/security/auditLog/queries" -Body $body -ContentType "application/json"
+            }
+
+            $scanId = $response.id
+            $summary.SearchId = $scanId
+
+            if (-not $StateFile) {
+                $StateFile = Join-Path -Path (Get-Location) -ChildPath "$searchName-UALGraph-state.json"
+            }
+
+            $state = @{
+                searchName           = $searchName
+                scanId               = $scanId
+                nextLink             = $null
+                totalEventsProcessed = 0
+                currentFileEvents    = 0
+                fileCounter          = $null
+                firstRecordInFile    = $null
+                outputFileBase       = $null
+                outputFilePath       = $null
+                filePath             = $null
+                outputDirPath        = $outputDirPath
+                outputFormat         = $Output
+                splitFiles           = [bool]$SplitFiles
+                encoding             = $Encoding
+                maxEventsPerFile     = $MaxEventsPerFile
+                searchStatus         = "created"
+                startedAt            = (Get-Date).ToString('o')
+                lastUpdated          = (Get-Date).ToString('o')
+            }
+
+            Save-StateFile -State $state -StateFilePath $StateFile
+            Write-LogFile -Message "[INFO] State file created: $StateFile" -Level Standard
+
+            Write-LogFile -Message "[INFO] A new Unified Audit Log search has started with the name: $($state.searchName) and ID: $scanId." -Color "Green" -Level Minimal
+
+            if ($isDebugEnabled) {
+                Write-LogFile -Message "[DEBUG] Search created successfully:" -Level Debug
+                Write-LogFile -Message "[DEBUG]   Search ID: $scanId" -Level Debug
+                Write-LogFile -Message "[DEBUG]   Response status: $($response.status)" -Level Debug
+            }
+
+            Start-Sleep -Seconds 10
+            $apiUrl = "https://graph.microsoft.com/beta/security/auditLog/queries/$scanId"
+            Write-LogFile -Message "[INFO] Waiting for the scan to start..." -Level Standard
+        }
+        catch {
+            Write-logFile -Message "[ERROR] An error occurred: $($_.Exception.Message)" -Color "Red" -Level Minimal
+            if ($isDebugEnabled) {
+                Write-LogFile -Message "[DEBUG] Error details:" -Level Debug
+                Write-LogFile -Message "[DEBUG]   Exception type: $($_.Exception.GetType().Name)" -Level Debug
+                Write-LogFile -Message "[DEBUG]   Error message: $($_.Exception.Message)" -Level Debug
+                Write-LogFile -Message "[DEBUG]   Stack trace: $($_.ScriptStackTrace)" -Level Debug
+            }
+            throw
+        }
+    }
+
+    if (-not $searchSucceeded) {
         $lastStatus = ""
         do {
             $response = Invoke-MgGraphRequest -Method Get -Uri $apiUrl -ContentType 'application/json'
@@ -201,6 +194,7 @@ Function Get-UALGraph {
             }
             Start-Sleep -Seconds 5
         } while ($status -ne "succeeded" -and $status -ne "running")
+
         if ($status -eq "running") {
             write-logFile -Message "[INFO] Unified Audit Log search has started... This can take a while..." -Level Standard
             do {
@@ -216,81 +210,70 @@ Function Get-UALGraph {
                 Start-Sleep -Seconds 5
             } while ($status -ne "succeeded")
         }
-       write-logFile -Message "[INFO] Unified Audit Log search complete." -Level Minimal
+        Write-LogFile -Message "[INFO] Unified Audit Log search complete." -Level Minimal
+        $state.searchStatus = "succeeded"
+        Save-StateFile -State $state -StateFilePath $StateFile
     }
-    catch {
-        Write-logFile -Message "[ERROR] An error occurred: $($_.Exception.Message)" -Color "Red" -Level Minimal
-        if ($isDebugEnabled) {
-            Write-LogFile -Message "[DEBUG] Error details:" -Level Debug
-            Write-LogFile -Message "[DEBUG]   Exception type: $($_.Exception.GetType().Name)" -Level Debug
-            Write-LogFile -Message "[DEBUG]   Error message: $($_.Exception.Message)" -Level Debug
-            Write-LogFile -Message "[DEBUG]   Stack trace: $($_.ScriptStackTrace)" -Level Debug
-        }
-        throw
+    else {
+        Write-LogFile -Message "[INFO] Resuming from previously completed search." -Level Standard
     }
 
     try {
         write-logFile -Message "[INFO] Collecting scan results from api (this may take a while)" -Level Standard
-        $date = [datetime]::Now.ToString('yyyyMMddHHmmss') 
 
-        $fileCounter = 1
-        $currentFileEvents = 0
-        $totalEvents = 0
-        $outputFileBase = "$($date)-$searchName-UnifiedAuditLog"
-
-        if ($SplitFiles) {
-            if ($Output -eq "JSON") {
-                $outputFilePath = "$outputFileBase-part$fileCounter.json"
-                $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
-                "[" | Out-File -FilePath $filePath -Encoding $Encoding
-                $firstRecordInFile = $true
-            } 
-            elseif ($Output -eq "CSV") {
-                $outputFilePath = "$outputFileBase-part$fileCounter.csv"
-                $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
-                $csvCollection = @()
-            }
-            elseif ($Output -eq "JSONL") {
-                $outputFilePath = "$outputFileBase-part$fileCounter.jsonl"
-                $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
-                $firstRecordInFile = $true
-            }
-            elseif ($Output -eq "SOF-ELK") {
-                $outputFilePath = "$outputFileBase-part$fileCounter.json"
-                $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
-            }
-        } 
-        else {
-            if ($Output -eq "JSON") {
-                $outputFilePath = "$outputFileBase.json"
-                $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
-                "[" | Out-File -FilePath $filePath -Encoding $Encoding
-                $firstRecordInFile = $true
-            }
-            elseif ($Output -eq "CSV") {
-                $outputFilePath = "$outputFileBase.csv"
-                $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
-                $csvCollection = @()
-            }
-            elseif ($Output -eq "JSONL") {
-                $outputFilePath = "$outputFileBase.jsonl"
-                $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
-                $firstRecordInFile = $true
-            }
-            elseif ($Output -eq "SOF-ELK") {
-                $outputFilePath = "$outputFileBase.json"
-                $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
+        if ($Resume) {
+            if ($state.outputFormat -eq "JSON") {
+                Write-LogFile -Message "[ERROR] Cannot resume with JSON output format. JSON files may be corrupted on crash due to bracket/comma encoding. Use JSONL, CSV, or SOF-ELK for resumable exports." -Color "Red" -Level Minimal
+                throw "Resume is not supported with JSON output format. Please use -Output JSONL, CSV, or SOF-ELK instead."
             }
         }
+        else {
+            $state.totalEventsProcessed = 0
+        }
+
+        if (-not $state.outputFileBase) {
+            $date = [datetime]::Now.ToString('yyyyMMddHHmmss')
+            $state.fileCounter = 1
+            $state.currentFileEvents = 0
+            $state.outputFileBase = "$($date)-$($state.searchName)-UnifiedAuditLog"
+            $state.firstRecordInFile = $true
+
+            $fileExtension = switch ($state.outputFormat) {
+                "CSV" { "csv" }
+                "JSONL" { "jsonl" }
+                default { "json" }
+            }
+            $fileSuffix = if ($state.splitFiles) { "-part$($state.fileCounter)" } else { "" }
+            $state.outputFilePath = "$($state.outputFileBase)$fileSuffix.$fileExtension"
+            $state.filePath = Join-Path -Path $state.outputDirPath -ChildPath $state.outputFilePath
+
+            if ($state.outputFormat -eq "JSON") {
+                "[" | Out-File -FilePath $state.filePath -Encoding $state.encoding
+            }
+
+            Save-StateFile -State $state -StateFilePath $StateFile
+        }
+
 
         if ($isDebugEnabled) {
             Write-LogFile -Message "[DEBUG] Starting data collection:" -Level Debug
-            Write-LogFile -Message "[DEBUG]   Split files: $SplitFiles" -Level Debug
-            Write-LogFile -Message "[DEBUG]   Max events per file: $MaxEventsPerFile" -Level Debug
-            Write-LogFile -Message "[DEBUG]   Initial file path: $filePath" -Level Debug
+            Write-LogFile -Message "[DEBUG]   Split files: $($state.splitFiles)" -Level Debug
+            Write-LogFile -Message "[DEBUG]   Max events per file: $($state.maxEventsPerFile)" -Level Debug
+            Write-LogFile -Message "[DEBUG]   Initial file path: $($state.filePath)" -Level Debug
         }
 
-        $apiUrl = "https://graph.microsoft.com/beta/security/auditLog/queries/$scanId/records"
+        if ($Resume -and $state.nextLink) {
+            $apiUrl = $state.nextLink
+            Write-LogFile -Message "[INFO] Resuming from saved position..." -Level Standard
+        }
+        else {
+            if ($BatchSize) {
+                $apiUrl = "https://graph.microsoft.com/beta/security/auditLog/queries/$($state.scanId)/records?`$top=$BatchSize"
+            }
+            else {
+                $apiUrl = "https://graph.microsoft.com/beta/security/auditLog/queries/$($state.scanId)/records"
+            }
+        }
         Write-LogFile -Message "[INFO] Starting to collect records..." -Level Standard
 
         Do {
@@ -321,13 +304,12 @@ Function Get-UALGraph {
                         Write-LogFile -Message "[DEBUG]   Error message: $errorMessage" -Level Debug
                         Write-LogFile -Message "[DEBUG]   Retry count: $retryCount of $maxRetries" -Level Debug
                     }
-                    
-                    
+
                     if ($retryCount -lt $maxRetries) {
                         $waitTime = 30 * $retryCount
                         Write-LogFile -Message "[WARNING] Error: $errorMessage. Retry $retryCount of $maxRetries. Waiting $waitTime seconds before retrying..." -Color "Yellow" -Level Standard
                         Start-Sleep -Seconds $waitTime
-                        
+
                         try {
                             $graphAuth = Get-GraphAuthType -RequiredScopes $RequiredScopes
                             Write-LogFile -Message "[INFO] Successfully refreshed Graph API connection." -Level Standard
@@ -338,158 +320,175 @@ Function Get-UALGraph {
                     }
                     else {
                         Write-LogFile -Message "[ERROR] Failed after $maxRetries attempts: $errorMessage" -Color "Red" -Level Minimal
-                        throw $_  
+                        throw $_
                     }
                 }
             }
 
-            $responseJson = $response | ConvertFrom-Json 
+            $responseJson = $response | ConvertFrom-Json -Depth 100
+
+            Write-LogFile -Message "[DEBUG] Retrieved batch data, records count: $($responseJson.value.Count)" -Level Standard
 
             if ($responseJson.value -and $responseJson.value.Count -gt 0) {
                 $batchCount = $responseJson.value.Count
-                $totalEvents += $batchCount
+                $state.totalEventsProcessed += $batchCount
 
                 if ($isDebugEnabled) {
-                    Write-LogFile -Message "[DEBUG] Processing batch: $batchCount records (Total: $totalEvents)" -Level Debug
-                    Write-LogFile -Message "[DEBUG] Current file events: $currentFileEvents" -Level Debug
+                    Write-LogFile -Message "[DEBUG] Processing batch: $batchCount records (Total: $($state.totalEventsProcessed))" -Level Debug
+                    Write-LogFile -Message "[DEBUG] Current file events: $($state.currentFileEvents)" -Level Debug
                 }
 
-                if ($Output -eq "JSON") {
+                if ($state.outputFormat -eq "JSON") {
                     foreach ($record in $responseJson.value) {
-                        if ($SplitFiles -and $currentFileEvents -ge $MaxEventsPerFile) {
-                            "]" | Out-File -FilePath $filePath -Append -Encoding $Encoding
-                            Write-LogFile -Message "[INFO] File complete: $outputFilePath ($currentFileEvents events)" -Level Standard
-                            
-                            $fileCounter++
+                        if ($state.splitFiles -and $state.currentFileEvents -ge $state.maxEventsPerFile) {
+                            "]" | Out-File -FilePath $state.filePath -Append -Encoding $state.encoding
+                            Write-LogFile -Message "[INFO] File complete: $($state.outputFilePath) ($($state.currentFileEvents) events)" -Level Standard
+
+                            $state.fileCounter++
                             $summary.ExportedFiles++
-                            $currentFileEvents = 0
-                            
-                            $outputFilePath = "$outputFileBase-part$fileCounter.json"
-                            $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
-                            "[" | Out-File -FilePath $filePath -Encoding $Encoding
-                            $firstRecordInFile = $true
+                            $state.currentFileEvents = 0
+
+                            $state.outputFilePath = "$($state.outputFileBase)-part$($state.fileCounter).json"
+                            $state.filePath = Join-Path -Path $state.outputDirPath -ChildPath $state.outputFilePath
+                            "[" | Out-File -FilePath $state.filePath -Encoding $state.encoding
+                            $state.firstRecordInFile = $true
                         }
 
-                        if (-not $firstRecordInFile) {
-                            "," | Out-File -FilePath $filePath -Append -Encoding $Encoding -NoNewline
-                        } else {
-                            $firstRecordInFile = $false
+                        if (-not $state.firstRecordInFile) {
+                            "," | Out-File -FilePath $state.filePath -Append -Encoding $state.encoding -NoNewline
                         }
-                        "`r`n" | Out-File -FilePath $filePath -Append -Encoding $Encoding -NoNewline
+                        else {
+                            $state.firstRecordInFile = $false
+                        }
+                        "`r`n" | Out-File -FilePath $state.filePath -Append -Encoding $state.encoding -NoNewline
 
-                        $record | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath -Append -Encoding $Encoding -NoNewline
+                        $record | ConvertTo-Json -Depth 100 | Out-File -FilePath $state.filePath -Append -Encoding $state.encoding -NoNewline
 
-                        $currentFileEvents++
+                        $state.currentFileEvents++
                         $summary.ProcessedRecords++
                     }
                 }
-                elseif ($Output -eq "CSV") {
-                    $csvCollection += $responseJson.value
-                    $currentFileEvents += $batchCount
-                    $summary.ProcessedRecords += $batchCount
+                elseif ($state.outputFormat -eq "CSV") {
+                    if (-not $state.splitFiles -or ($state.currentFileEvents + $batchCount) -le [int]$state.maxEventsPerFile) {
+                        $responseJson.value | Format-AuditRecordForCsv | Export-Csv -Path $state.filePath -Append -Encoding $state.encoding -NoTypeInformation
+                        $state.currentFileEvents += $batchCount
+                        $summary.ProcessedRecords += $batchCount
+                    }
+                    else {
+                        $records = $responseJson.value
+                        $recordIndex = 0
+                        while ($recordIndex -lt $records.Count) {
+                            $remaining = [int]$state.maxEventsPerFile - $state.currentFileEvents
+                            $toWrite = [Math]::Min($remaining, $records.Count - $recordIndex)
 
-                    if ($SplitFiles -and $currentFileEvents -ge $MaxEventsPerFile) {
-                        $csvCollection | Select-Object id, createdDateTime, auditLogRecordType, operation, organizationId, userType, userId, service, objectId, userPrincipalName, clientIp, administrativeUnits, @{Name = "auditData"; Expression = { $_.auditData | ConvertTo-Json -Depth 100 } } | Export-Csv -Path $filePath -Append -Encoding $Encoding -NoTypeInformation
-                        Write-LogFile -Message "[INFO] File complete: $outputFilePath ($currentFileEvents events)" -Level Standard
-                        
-                        $fileCounter++
-                        $summary.ExportedFiles++
-                        $currentFileEvents = 0
-                        
-                        $csvCollection = @()
-                        $outputFilePath = "$outputFileBase-part$fileCounter.csv"
-                        $filePath = Join-Path -Path $OutputDir -ChildPath $outputFilePath
+                            if ($toWrite -gt 0) {
+                                $records[$recordIndex..($recordIndex + $toWrite - 1)] | Format-AuditRecordForCsv | Export-Csv -Path $state.filePath -Append -Encoding $state.encoding -NoTypeInformation
+                                $state.currentFileEvents += $toWrite
+                                $summary.ProcessedRecords += $toWrite
+                                $recordIndex += $toWrite
+                            }
+
+                            if ($state.currentFileEvents -ge [int]$state.maxEventsPerFile -and $recordIndex -lt $records.Count) {
+                                Write-LogFile -Message "[INFO] File complete: $($state.outputFilePath) ($($state.currentFileEvents) events)" -Level Standard
+                                $state.fileCounter++
+                                $summary.ExportedFiles++
+                                $state.currentFileEvents = 0
+                                $state.outputFilePath = "$($state.outputFileBase)-part$($state.fileCounter).csv"
+                                $state.filePath = Join-Path -Path $state.outputDirPath -ChildPath $state.outputFilePath
+                            }
+                        }
                     }
                 }
-                elseif ($Output -eq "JSONL") {
+                elseif ($state.outputFormat -eq "JSONL") {
                     foreach ($record in $responseJson.value) {
-                        if ($SplitFiles -and $currentFileEvents -ge $MaxEventsPerFile) {
-                            Write-LogFile -Message "[INFO] File complete: $outputFilePath ($currentFileEvents events)" -Level Standard
-                            
-                            $fileCounter++
-                            $summary.ExportedFiles++
-                            $currentFileEvents = 0
+                        if ($state.splitFiles -and $state.currentFileEvents -ge $state.maxEventsPerFile) {
+                            Write-LogFile -Message "[INFO] File complete: $($state.outputFilePath) ($($state.currentFileEvents) events)" -Level Standard
 
-                            $outputFilePath = "$outputFileBase-part$fileCounter.jsonl"
-                            $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
+                            $state.fileCounter++
+                            $summary.ExportedFiles++
+                            $state.currentFileEvents = 0
+
+                            $state.outputFilePath = "$($state.outputFileBase)-part$($state.fileCounter).jsonl"
+                            $state.filePath = Join-Path -Path $state.outputDirPath -ChildPath $state.outputFilePath
                         }
                         if ($record.auditData) {
-                            $record.auditData | ConvertTo-Json -Compress -Depth 100 | 
-                                Out-File -Append $filePath -Encoding UTF8
+                            $record.auditData | ConvertTo-Json -Compress -Depth 100 |
+                            Out-File -Append $state.filePath -Encoding UTF8
                         }
-                        "`r`n" | Out-File -FilePath $filePath -Append -Encoding UTF8
-                        $currentFileEvents++
+                        "`r`n" | Out-File -FilePath $state.filePath -Append -Encoding UTF8
+                        $state.currentFileEvents++
                         $summary.ProcessedRecords++
                     }
                 }
-                elseif ($Output -eq "SOF-ELK") {
+                elseif ($state.outputFormat -eq "SOF-ELK") {
                     foreach ($record in $responseJson.value) {
-                        if ($SplitFiles -and $currentFileEvents -ge $MaxEventsPerFile) {
-                            Write-LogFile -Message "[INFO] File complete: $outputFilePath ($currentFileEvents events)" -Level Standard
-                            
-                            $fileCounter++
-                            $summary.ExportedFiles++
-                            $currentFileEvents = 0
+                        if ($state.splitFiles -and $state.currentFileEvents -ge $state.maxEventsPerFile) {
+                            Write-LogFile -Message "[INFO] File complete: $($state.outputFilePath) ($($state.currentFileEvents) events)" -Level Standard
 
-                            $outputFilePath = "$outputFileBase-part$fileCounter.json"
-                            $filePath = Join-Path -Path $outputDirPath -ChildPath $outputFilePath
+                            $state.fileCounter++
+                            $summary.ExportedFiles++
+                            $state.currentFileEvents = 0
+
+                            $state.outputFilePath = "$($state.outputFileBase)-part$($state.fileCounter).json"
+                            $state.filePath = Join-Path -Path $state.outputDirPath -ChildPath $state.outputFilePath
                         }
                         if ($record.auditData) {
-                            $record.auditData | ConvertTo-Json -Compress -Depth 100 | 
-                                Out-File -Append $filePath -Encoding UTF8
+                            $record.auditData | ConvertTo-Json -Compress -Depth 100 |
+                            Out-File -Append $state.filePath -Encoding UTF8
                         }
-                        $currentFileEvents++
+                        $state.currentFileEvents++
                         $summary.ProcessedRecords++
                     }
                 }
 
-                if ($totalEvents % 10000 -eq 0 -or $batchCount -lt 100) {
-                    Write-LogFile -Message "[INFO] Progress: $totalEvents total events processed" -Level Standard
+                if ($state.totalEventsProcessed % 10000 -eq 0 -or $batchCount -lt 100) {
+                    Write-LogFile -Message "[INFO] Progress: $($state.totalEventsProcessed) total events processed" -Level Standard
                     if ($isDebugEnabled) {
                         Write-LogFile -Message "[DEBUG] Progress details:" -Level Debug
                         Write-LogFile -Message "[DEBUG]   Batch size: $batchCount" -Level Debug
-                        Write-LogFile -Message "[DEBUG]   Current file: $outputFilePath" -Level Debug
+                        Write-LogFile -Message "[DEBUG]   Current file: $($state.outputFilePath)" -Level Debug
                         Write-LogFile -Message "[DEBUG]   Current file events: $currentFileEvents" -Level Debug
                     }
                 }
-            } else {
-                if ($totalEvents -eq 0) {
+            }
+            else {
+                if ($state.totalEventsProcessed -eq 0) {
                     Write-LogFile -Message "[INFO] No results matched your search." -Color Yellow -Level Minimal
                 }
             }
             $apiUrl = $responseJson.'@odata.nextLink'
+
+            $state.nextLink = $apiUrl
+
+            Save-StateFile -State $state -StateFilePath $StateFile
         } While ($apiUrl)
 
-        if ($currentFileEvents -gt 0) {
+        if ($state.currentFileEvents -gt 0) {
             if ($Output -eq "JSON") {
-                "]" | Out-File -FilePath $filePath -Append -Encoding $Encoding
-            }
-            elseif ($Output -eq "CSV" -and $csvCollection.Count -gt 0) {
-                $csvCollection | Select-Object id, createdDateTime, auditLogRecordType, operation, organizationId, userType, userId, service, objectId, userPrincipalName, clientIp, administrativeUnits, @{Name = "auditData"; Expression = { $_.auditData | ConvertTo-Json -Depth 100 } } | Export-Csv -Path $filePath -Append -Encoding $Encoding -NoTypeInformation
-
-                
+                "]" | Out-File -FilePath $state.filePath -Append -Encoding $Encoding
             }
             $summary.ExportedFiles++
         }
 
-        $summary.TotalRecords = $totalEvents
+        $summary.TotalRecords = $state.totalEventsProcessed
         $summary.ProcessingTime = (Get-Date) - $summary.StartTime
 
         $summaryOutput = [ordered]@{
-            "Search Information" = [ordered]@{
+            "Search Information"    = [ordered]@{
                 "Search Name" = $SearchName
-                "Search ID" = $summary.SearchId
+                "Search ID"   = $summary.SearchId
                 "Time Period" = $dateRange
             }
             "Collection Statistics" = [ordered]@{
                 "Total Records Retrieved" = $summary.TotalRecords
-                "Files Created" = $summary.ExportedFiles
+                "Files Created"           = $summary.ExportedFiles
             }
-            "Export Details" = [ordered]@{
+            "Export Details"        = [ordered]@{
                 "Output Directory" = $outputDirPath
-                "Processing Time" = if ($summary.ProcessingTime.Days -gt 0) {
+                "Processing Time"  = if ($summary.ProcessingTime.Days -gt 0) {
                     "$($summary.ProcessingTime.Days) days, $($summary.ProcessingTime.Hours):$($summary.ProcessingTime.Minutes.ToString('00')):$($summary.ProcessingTime.Seconds.ToString('00'))"
-                } else {
+                }
+                else {
                     $summary.ProcessingTime.ToString('hh\:mm\:ss')
                 }
             }
@@ -500,13 +499,14 @@ Function Get-UALGraph {
         }
 
         Write-Summary -Summary $summaryOutput -Title "Audit Log Retrieval Summary" -SkipExportDetails
+
+        if (Test-Path $StateFile) {
+            Remove-Item -Path $StateFile -Force
+            Write-LogFile -Message "[INFO] State file removed after successful completion" -Level Standard
+        }
     }
     catch {
         Write-logFile -Message "[ERROR] An error occurred: $($_.Exception.Message)" -Color "Red" -Level Minimal
         throw
     }
 }
-            
-            
-            
-            


### PR DESCRIPTION
- Adds resumable export capability using a state file (via -Resume and -StateFile parameters), allowing interrupted exports to continue.
- Introduces a BatchSize parameter (up to 5000, based on experimental results), which significantly speeds up log export by increasing the number of records retrieved per API call.
- Implements helper functions for CSV formatting and state file management.
- Refactors output file handling for robust splitting, progress tracking, and safe resumption.
- Improves error handling, logging, and debug output.
- Ensures state file cleanup after successful completion.