### PR TITLE
Remove stale function exports from .psd1

### DIFF
--- a/Microsoft-Extractor-Suite.psd1
+++ b/Microsoft-Extractor-Suite.psd1
@@ -58,7 +58,6 @@
 		
 		# Disconnect.ps1
 		"Disconnect-M365"
-		"Disconnect-Azure"
 		"Disconnect-AzureAZ"
 
 		# Get-UAL.ps1

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ You must sign-in to Microsoft 365 or Azure depending on your use case before run
 - `Get-DirectoryActivityLogs` - Collect directory activity logs
 
 ### OAuth apps
-- `Get-OAuthPermissions` - Collect OAuth application permissions Via AZ module
 - `Get-OAuthPermissionsGraph` - Collect OAuth application permissions via Graph API
 
 ### User Related
@@ -137,10 +136,8 @@ You must sign-in to Microsoft 365 or Azure depending on your use case before run
 
 ### Authentication & Session Management
 - `Connect-M365` - Connect to Microsoft 365 services
-- `Connect-Azure` - Connect to Azure/Entra ID
 - `Connect-AzureAZ` - Connect using Az module
 - `Disconnect-M365` - Disconnect from Microsoft 365 services
-- `Disconnect-Azure` - Disconnect from Azure/Entra ID
 - `Disconnect-AzureAZ` - Disconnect from Az module session
 
 ## Related Projects

--- a/Scripts/Disconnect.ps1
+++ b/Scripts/Disconnect.ps1
@@ -4,12 +4,6 @@ Function Disconnect-M365
     Remove-Module ExchangeOnlineManagement -Force > $null;
 }
 
-Function Disconnect-Azure
-{
-    Disconnect-MgGraph > $null;
-    Remove-Module Microsoft.Graph -Force > $null;
-}
-
 Function Disconnect-AzureAZ
 {
     Clear-AzContext -Force > $null;

--- a/docs/source/functionality/Azure/OAuthPermissions.rst
+++ b/docs/source/functionality/Azure/OAuthPermissions.rst
@@ -2,38 +2,6 @@ OAuth Permissions
 =======
 OAuth is a way of authorizing third-party applications to login into user accounts such as social media and webmail. The advantage of OAuth is that users don’t have to reveal their password; instead, the third-party applications use a token for authentication. In an OAuth abuse attack, a victim authorizes a third-party application to access their account. Once authorized, the application accesses the user’s data without the need for credentials. The user receives a message to accept the application with its requested API permissions. After the user selects accept, the threat actor has control of the user’s account.
 
-.. note::
-
-   Script made by psignoret: https://gist.github.com/psignoret/41793f8c6211d2df5051d77ca3728c09
-
-Parameters
-""""""""""""""""""""""""""
--OutputDir (optional)
-    - OutputDir is the parameter specifying the output directory.
-    - Default: Output\OAuthPermissions
-
--Encoding (optional)
-    - Encoding is the parameter specifying the encoding of the CSV output file.
-    - Default: UTF8
-
--LogLevel (optional)
-    - Specifies the level of logging. None: No logging. Minimal: Logs critical errors only. Standard: Normal operational logging. Debug: Detailed logging for debugging.
-    - Default: Standard
-
-Usage
-""""""""""""""""""""""""""
-List delegated permissions (OAuth2PermissionGrants) and application permissions (AppRoleAssignments):
-::
-
-   Get-OAuthPermissions
-
-Output
-""""""""""""""""""""""""""
-The output will be saved to the 'OAuthPermissions' directory within the 'Output' directory, with the file name 'OAuthPermissions.csv'.
-
-Graph API Variant
-^^^^^^^^^^^
-
 Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 -OutputDir (optional)


### PR DESCRIPTION
This PR removes `Connect-Azure` and `Get-OAuthPermissions` from FunctionsToExport in Microsoft-Extractor-Suite.psd1.

Both functions are listed in the manifest but are not implemented in any script under Scripts/ and are not exported at runtime. The actual