### PR TITLE
Add option to continue UAL Graph collection

### DIFF
--- a/Scripts/Get-UALGraph.ps1
+++ b/Scripts/Get-UALGraph.ps1
@@ -69,6 +69,10 @@ Function Get-UALGraph {
     .PARAMETER SearchName
     Specifies the name of the search query. This parameter is required.
 
+    .PARAMETER SearchId
+    Specifies the ID of an existing search to resume or collect results from. 
+    If provided, the function skips creating a new search and checks the status of this ID.
+
     .PARAMETER SplitFiles
     When specified, splits output into multiple files based on MaxEventsPerFile.
     When set to True, splits output into multiple files based on MaxEventsPerFile.
@@ -78,7 +82,7 @@ Function Get-UALGraph {
     Exact data returned depends on the service in the current `@odatatype.microsoft.graph.security.auditLogQuery` record.
     For Exchange admin audit logging, the name of the object modified by the cmdlet.
     For SharePoint activity, the full URL path name of the file or folder accessed by a user. 
-    For Microsoft Entra activity, the name of the user account that was modified.|
+    For Microsoft Entra activity, the name of the user account that was modified.
     
     .EXAMPLE
     Get-UALGraph -searchName Test 

--- a/docs/source/functionality/M365/UnifiedAuditLogGraph.rst
+++ b/docs/source/functionality/M365/UnifiedAuditLogGraph.rst
@@ -42,6 +42,9 @@ Parameters
 -SearchName (required)
     - Specifies the name of the search query. This parameter is required.
 
+-SearchId (optional)
+    - Specifies the ID of an existing search. If provided, the function collects results from this search instead of starting a new one.
+
 -UserIds (optional)
     - UserIds is the UserIds parameter filtering the log entries by the account of the user who performed the actions.
 


### PR DESCRIPTION
If your powershell crashes (or something else happens) during collection of the UAL through Graph it will actually still be running at Microsoft. This MR adds an option to specify the `SearchId` that has been generated before. If you provide this it will skip the creation of the job and goes straight into checking the state and fetching the results.