### PR TITLE
Fixing bug with UAL collection using custom output directory

### DIFF
--- a/Scripts/Start-MESTriage.ps1
+++ b/Scripts/Start-MESTriage.ps1
@@ -408,13 +408,12 @@ function Invoke-TriageTask {
             return $true
         }
         "Get-UAL" {
-            $OutputDirAudit = "$OutputDir\Unified Audit Logs"
             $taskOutput = Get-TaskOutputFormat -TaskName $TaskName -RequestedOutput $Output -JSONLSupportedFunctions $JSONLSupportedFunctions -SOFELKSupportedFunctions $SOFELKSupportedFunctions
             if ($UserIds.Count -gt 0) {
                 $userIdsString = $UserIds -join ',' 
-                Get-UAL -OutputDir $OutputDirAudit -LogLevel $LogLevel -UserIds $userIdsString -Output $taskOutput -Encoding $Encoding -StartDate $StartDate -EndDate $EndDate -MergeOutput
+                Get-UAL -OutputDir $OutputDir -LogLevel $LogLevel -UserIds $userIdsString -Output $taskOutput -Encoding $Encoding -StartDate $StartDate -EndDate $EndDate -MergeOutput
             } else {
-                Get-UAL -OutputDir $OutputDirAudit -LogLevel $LogLevel -Output $taskOutput -Encoding $Encoding -StartDate $StartDate -EndDate $EndDate -MergeOutput
+                Get-UAL -OutputDir $OutputDir -LogLevel $LogLevel -Output $taskOutput -Encoding $Encoding -StartDate $StartDate -EndDate $EndDate -MergeOutput
             }
             return $true
         }


### PR DESCRIPTION
Hi there, while using the tool I found that it consistently breaks using the MESTriage script if using the Get-UAL value in a template instead of manually specifying the specific fields. 

Observed when using a custom outputdir that contains "../".  