### PR TITLE
Implement -UseV1 switch for Get-UALGraph cmdlet

### DIFF
--- a/Scripts/Get-UALGraph.ps1
+++ b/Scripts/Get-UALGraph.ps1
@@ -78,12 +78,18 @@ Function Get-UALGraph {
     When set to True, splits output into multiple files based on MaxEventsPerFile.
     Default: If not specified, outputs to a single file.
 
-    .PARAMETER ObjectIDs 
+    .PARAMETER ObjectIDs
     Exact data returned depends on the service in the current `@odatatype.microsoft.graph.security.auditLogQuery` record.
     For Exchange admin audit logging, the name of the object modified by the cmdlet.
-    For SharePoint activity, the full URL path name of the file or folder accessed by a user. 
+    For SharePoint activity, the full URL path name of the file or folder accessed by a user.
     For Microsoft Entra activity, the name of the user account that was modified.
-    
+
+    .PARAMETER UseV1
+    When specified, uses the v1.0 Microsoft Graph API endpoint instead of the default beta endpoint.
+    By default, the beta endpoint (https://graph.microsoft.com/beta/security/auditLog/queries) is used
+    because both endpoints have experienced reliability issues and the beta endpoint is currently more
+    stable. Use this switch to opt-in to the v1.0 endpoint when it is available and stable in your tenant.
+
     .EXAMPLE
     Get-UALGraph -searchName Test 
     Gets all the unified audit log entries.
@@ -125,7 +131,8 @@ Function Get-UALGraph {
         [ValidateSet("CSV", "JSON", "JSONL", "SOF-ELK")]
         [string]$Output = "JSON",
         [switch]$SplitFiles,
-        [string]$SearchId = ""
+        [string]$SearchId = "",
+        [switch]$UseV1
     )
 
     Init-OutputDir -Component "UnifiedAuditLog" -FilePostfix $searchName -CustomOutputDir $OutputDir
@@ -155,6 +162,14 @@ Function Get-UALGraph {
     Write-LogFile -Message "Output format: $Output" -Level Standard
     Write-LogFile -Message "----------------------------------------`n" -Level Standard
 
+    if ($UseV1) {
+        $apiBase = "https://graph.microsoft.com/v1.0/security/auditLog/queries"
+        Write-LogFile -Message "[INFO] Using Microsoft Graph v1.0 endpoint." -Level Standard
+    } else {
+        $apiBase = "https://graph.microsoft.com/beta/security/auditLog/queries"
+        Write-LogFile -Message "[INFO] Using Microsoft Graph beta endpoint (default). Use -UseV1 to switch to v1.0." -Level Standard
+    }
+
     $body = @{
         "@odata.type" = "#microsoft.graph.security.auditLogQuery"
         displayName = $searchName
@@ -178,13 +193,13 @@ Function Get-UALGraph {
             {
                 Write-LogFile -Message "[DEBUG] Initiating Graph API audit log query..." -Level Debug
                 $createPerformance = Measure-Command {
-                    $response = Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/security/auditLog/queries" -Body $body -ContentType "application/json"
+                    $response = Invoke-MgGraphRequest -Method POST -Uri $apiBase -Body $body -ContentType "application/json"
                 }
                 Write-LogFile -Message "[DEBUG] Query creation took $([math]::round($createPerformance.TotalSeconds, 2) ) seconds" -Level Debug
             }
             else
             {
-                $response = Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/security/auditLog/queries" -Body $body -ContentType "application/json"
+                $response = Invoke-MgGraphRequest -Method POST -Uri $apiBase -Body $body -ContentType "application/json"
             }
 
             $scanId = $response.id
@@ -204,7 +219,7 @@ Function Get-UALGraph {
         }
 
         Start-Sleep -Seconds 10
-        $apiUrl = "https://graph.microsoft.com/beta/security/auditLog/queries/$scanId"
+        $apiUrl = "$apiBase/$scanId"
 
         write-logFile -Message "[INFO] Waiting for the scan to start..." -Level Standard
         $lastStatus = ""
@@ -306,7 +321,7 @@ Function Get-UALGraph {
             Write-LogFile -Message "[DEBUG]   Initial file path: $filePath" -Level Debug
         }
 
-        $apiUrl = "https://graph.microsoft.com/beta/security/auditLog/queries/$scanId/records"
+        $apiUrl = "$apiBase/$scanId/records"
         Write-LogFile -Message "[INFO] Starting to collect records..." -Level Standard
 
         Do {

--- a/docs/source/functionality/M365/UnifiedAuditLogGraph.rst
+++ b/docs/source/functionality/M365/UnifiedAuditLogGraph.rst
@@ -37,6 +37,18 @@ Retrieve audit log data for the specified time range March 1, 2025 to March 10, 
 
    Get-UALGraph -searchName scan1 -startDate "2025-03-01" -endDate "2025-03-10" -IPAddress 182.74.242.26
 
+Uses the v1.0 Microsoft Graph endpoint instead of the default beta endpoint:
+::
+
+   Get-UALGraph -SearchName Test -UseV1
+
+.. note::
+
+  By default, ``Get-UALGraph`` uses the **beta** endpoint (``https://graph.microsoft.com/beta/security/auditLog/queries``).
+  Microsoft has experienced reliability issues with both the beta and v1.0 endpoints. The beta endpoint is the default
+  because it has proven more consistently available. Use ``-UseV1`` to opt in to the v1.0 endpoint if it is stable in
+  your tenant at the time of collection.
+
 Parameters
 """"""""""""""""""""""""""
 -SearchName (required)
@@ -103,6 +115,10 @@ Parameters
 -SplitFiles (optional)
     - When specified, splits output into multiple files based on MaxEventsPerFile.
     - Default: If not specified, outputs to a single file.
+
+-UseV1 (optional)
+    - When specified, uses the v1.0 Microsoft Graph API endpoint (``https://graph.microsoft.com/v1.0/security/auditLog/queries``) instead of the default beta endpoint.
+    - Default: beta endpoint is used. Both endpoints have experienced intermittent instability; use this flag to switch to v1.0 when it is available and stable in your tenant.
 
 Permissions
 """"""""""""""""""""""""""


### PR DESCRIPTION
This patch implements a `-UseV1` flag for the `Get-UALGraph` cmdlet and extends the documentation for it.

The patch was created based on the discussion in #189 and allows users to simply switch between the beta and V1 endpoints and check if the V1 endpoint works for them. It continues to use the beta endpoints by default. It is an alternative to patch #194.